### PR TITLE
Add macOS support, persistent history, and signed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Build Release Draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic version without the v prefix, for example 1.2.3
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --yes --no-progress
+      - name: Install bundled runtimes
+        shell: pwsh
+        run: |
+          .\install_ffmpeg_windows.ps1
+          .\install_deno_windows.ps1
+      - name: Build Windows installer and portable archive
+        shell: pwsh
+        run: .\build_and_package_windows.ps1 -Version "${{ inputs.version }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vodforge-windows
+          path: dist/release/*
+          if-no-files-found: error
+
+  macos:
+    strategy:
+      matrix:
+        include:
+          - os: macos-15
+            architecture: arm64
+          - os: macos-15-intel
+            architecture: x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: brew install python@3.13 python-tk@3.13 ffmpeg deno
+      - name: Build unsigned macOS application
+        run: ./build_and_package_macos.sh "${{ inputs.version }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vodforge-macos-${{ matrix.architecture }}-unsigned
+          path: dist/release/*
+          if-no-files-found: error
+
+  draft:
+    needs: [windows, macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: release
+          pattern: vodforge-*
+          merge-multiple: true
+      - name: Create checksums
+        working-directory: release
+        run: |
+          find . -maxdepth 1 -type f ! -name SHA256SUMS.txt -printf '%f\n' | sort | while read -r file; do
+            sha256sum "$file"
+          done > SHA256SUMS.txt
+      - name: Create review-only draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ inputs.version }}" release/* \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --title "VODForge v${{ inputs.version }}" \
+            --notes "Windows installer and portable archive, plus unsigned macOS review builds. Do not publish the draft until macOS Developer ID signing and notarization are complete." \
+            --draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,12 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   windows:
     runs-on: windows-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -28,9 +30,53 @@ jobs:
         run: |
           .\install_ffmpeg_windows.ps1
           .\install_deno_windows.ps1
-      - name: Build Windows installer and portable archive
+      - name: Build Windows application
         shell: pwsh
-        run: .\build_and_package_windows.ps1 -Version "${{ inputs.version }}"
+        env:
+          VODFORGE_BUILD_VERSION: ${{ inputs.version }}
+        run: .\build_windows.ps1
+      - name: Sign in to Azure with GitHub OIDC
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign packaged Windows application
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+          files: ${{ github.workspace }}\dist\VODForge\VODForge.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: VODForge
+          description-url: https://github.com/SnowfallHD/vodforge
+      - name: Verify packaged Windows application signatures
+        shell: pwsh
+        run: .\verify_windows_signatures.ps1 -Files @("${{ github.workspace }}\dist\VODForge\VODForge.exe")
+      - name: Build Windows installer
+        shell: pwsh
+        run: .\build_windows_installer.ps1 -Version "${{ inputs.version }}"
+      - name: Sign Windows installer
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_CERTIFICATE_PROFILE }}
+          files: ${{ github.workspace }}\dist\release\VODForge-Windows-Setup-v${{ inputs.version }}.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: VODForge Installer
+          description-url: https://github.com/SnowfallHD/vodforge
+      - name: Verify installer and package signed portable application
+        shell: pwsh
+        run: |
+          $installer = "${{ github.workspace }}\dist\release\VODForge-Windows-Setup-v${{ inputs.version }}.exe"
+          .\verify_windows_signatures.ps1 -Files @($installer)
+          Compress-Archive -Path .\dist\VODForge -DestinationPath ".\dist\release\VODForge-Windows-Portable-v${{ inputs.version }}.zip" -Force
       - uses: actions/upload-artifact@v4
         with:
           name: vodforge-windows
@@ -50,7 +96,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install build dependencies
         run: brew install python@3.13 python-tk@3.13 ffmpeg deno
-      - name: Build unsigned macOS application
+      - name: Build unsigned macOS review application
+        env:
+          VODFORGE_UNSIGNED_REVIEW: "1"
         run: ./build_and_package_macos.sh "${{ inputs.version }}"
       - uses: actions/upload-artifact@v4
         with:
@@ -81,5 +129,5 @@ jobs:
             --repo "${{ github.repository }}" \
             --target "${{ github.sha }}" \
             --title "VODForge v${{ inputs.version }}" \
-            --notes "Windows installer and portable archive, plus unsigned macOS review builds. Do not publish the draft until macOS Developer ID signing and notarization are complete." \
+            --notes "Signed Windows installer and portable archive, plus unsigned macOS review builds. Do not publish the draft until both macOS architectures are Developer ID signed, notarized, stapled, and the checksums are regenerated." \
             --draft

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11", "3.13"]
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ VODForge analyzes the available source streams, chooses a practical video/audio 
 
 GitHub Releases are the intended public download channel. On Windows, use the per-user `VODForge-Windows-Setup` installer. It installs under `%LOCALAPPDATA%\Programs\VODForge`, keeps the packaged `_internal` runtime beside the app automatically, adds normal shortcuts, and provides an uninstaller. The portable ZIP remains available for users who specifically want it.
 
-The macOS release is a normal `VODForge.app`; its bundled runtime is inside the application package. Public macOS releases must be Developer ID signed and notarized before publication. Unsigned workflow artifacts are review builds, not public-ready downloads.
+The macOS release is a normal `VODForge.app`; its bundled runtime is inside the application package. Public macOS releases are Developer ID signed, notarized, stapled, and Gatekeeper-checked before publication. Unsigned workflow artifacts are explicitly named `unsigned-review` and are never public-ready downloads.
 
 ## Quick start
 
@@ -145,7 +145,9 @@ The manually dispatched **Build Release Draft** GitHub Actions workflow builds:
 - separate Apple Silicon and Intel macOS review archives; and
 - `SHA256SUMS.txt` for every artifact.
 
-It creates a GitHub **draft** release only. That keeps review separate from publication and prevents unsigned macOS builds from being presented as public-ready. The app's update check reads only the latest public, stable GitHub Release. On Windows it downloads the matching installer, verifies its exact size and SHA-256 checksum from the same release, and starts the per-user updater; other platforms open the verified release page until their signed installation path is ready.
+It creates a GitHub **draft** release only. Windows application and installer signing uses Azure Artifact Signing through a repository-specific OIDC identity; no long-lived Azure password is stored in GitHub. The macOS jobs produce explicit unsigned review archives for both architectures. On the signing Mac, `./finalize_macos_release.sh <version>` downloads those review builds, Developer ID signs them, submits each to Apple notarization, staples and Gatekeeper-checks them, runs the packaged-runtime smoke tests, uploads the final archives, removes the unsigned review assets, and regenerates `SHA256SUMS.txt`.
+
+After the draft assets and checksums are reviewed, publishing the draft makes it the update source. The app's update check reads only the latest public, stable GitHub Release. On Windows it downloads the matching signed installer, verifies its exact size and SHA-256 checksum from the same release, and starts the updater. macOS opens the verified release page until an in-app signed replacement path is implemented.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ VODForge analyzes the available source streams, chooses a practical video/audio 
 - Keeps playlist and non-playlist downloads organized in collision-safe folders.
 - Includes browser-cookie and `cookies.txt` options for videos you are authorized to access.
 - Shows progress, speed, ETA, diagnostics, and per-item batch failures.
+- Keeps a private, local Metadata Browser history of completed downloads and their saved folders across app restarts.
+- Checks versioned, stable GitHub Releases for updates; it never installs code directly from the repository's `main` branch.
+
+## Install a packaged release
+
+GitHub Releases are the intended public download channel. On Windows, use the per-user `VODForge-Windows-Setup` installer. It installs under `%LOCALAPPDATA%\Programs\VODForge`, keeps the packaged `_internal` runtime beside the app automatically, adds normal shortcuts, and provides an uninstaller. The portable ZIP remains available for users who specifically want it.
+
+The macOS release is a normal `VODForge.app`; its bundled runtime is inside the application package. Public macOS releases must be Developer ID signed and notarized before publication. Unsigned workflow artifacts are review builds, not public-ready downloads.
 
 ## Quick start
 
@@ -78,6 +86,8 @@ Typical output:
 
 Diagnostics are written to `%LOCALAPPDATA%\VODForge\logs\` on Windows and `~/Library/Logs/VODForge/` on macOS.
 
+Completed-download history is written to `%LOCALAPPDATA%\VODForge\download-history.json` on Windows and `~/Library/Application Support/VODForge/download-history.json` on macOS. It contains an allow-listed copy of display metadata and the saved output folder. It never stores cookie files, cookie contents, tokens, passwords, or browser-session data. A missing external drive or moved folder is reported without deleting the history entry.
+
 ## Build the Windows app
 
 Install the portable dependencies, then build and smoke-test:
@@ -95,11 +105,13 @@ The runnable folder is created at:
 dist\VODForge\
 ```
 
-To build and package a ZIP:
+To build the primary per-user installer and the optional portable ZIP, install Inno Setup 6 and run:
 
 ```powershell
 .\build_and_package_windows.ps1 -Version "0.1.0"
 ```
+
+Use `-PortableOnly` only when you intentionally do not want an installer.
 
 ## Build the macOS app
 
@@ -123,6 +135,17 @@ To package an unsigned ZIP for internal testing:
 ```
 
 The build bundles FFmpeg, ffprobe, and Deno so a Finder-launched app does not depend on shell `PATH` configuration. Public distribution still requires an Apple Developer ID signature and notarization; the build scripts do not claim or perform those steps.
+
+## Release workflow
+
+The manually dispatched **Build Release Draft** GitHub Actions workflow builds:
+
+- a Windows per-user installer;
+- an optional Windows portable ZIP;
+- separate Apple Silicon and Intel macOS review archives; and
+- `SHA256SUMS.txt` for every artifact.
+
+It creates a GitHub **draft** release only. That keeps review separate from publication and prevents unsigned macOS builds from being presented as public-ready. The app's update check reads only the latest public, stable GitHub Release. On Windows it downloads the matching installer, verifies its exact size and SHA-256 checksum from the same release, and starts the per-user updater; other platforms open the verified release page until their signed installation path is ready.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Tests](https://github.com/SnowfallHD/vodforge/actions/workflows/tests.yml/badge.svg)](https://github.com/SnowfallHD/vodforge/actions/workflows/tests.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D4)](#quick-start)
+[![Platform: Windows | macOS](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-59636e)](#quick-start)
 
-A Windows desktop app that turns YouTube videos and playlists into organized, VOD-ready MP4 files using `yt-dlp` and FFmpeg.
+A Windows and macOS desktop app that turns YouTube videos and playlists into organized, VOD-ready MP4 files using `yt-dlp` and FFmpeg.
 
 VODForge analyzes the available source streams, chooses a practical video/audio pair, and exports predictable H.264/AAC files without pretending a low-quality source has more detail than it does.
 
@@ -23,7 +23,20 @@ VODForge analyzes the available source streams, chooses a practical video/audio 
 
 ## Quick start
 
-You need Windows and Python 3.11 or newer.
+You need Python 3.11 or newer with Tk support.
+
+### macOS
+
+Homebrew is used to install a Tk-enabled Python, FFmpeg, and Deno. The application remains a lightweight Python/Tk desktop app; it does not require Electron.
+
+```bash
+git clone https://github.com/SnowfallHD/vodforge.git
+cd vodforge
+./install_macos_dependencies.sh
+.venv/bin/python main.py
+```
+
+### Windows
 
 ```powershell
 git clone https://github.com/SnowfallHD/vodforge.git
@@ -63,7 +76,7 @@ Typical output:
             └── thumbnail.jpeg
 ```
 
-Diagnostics are written to `%LOCALAPPDATA%\VODForge\logs\`.
+Diagnostics are written to `%LOCALAPPDATA%\VODForge\logs\` on Windows and `~/Library/Logs/VODForge/` on macOS.
 
 ## Build the Windows app
 
@@ -88,7 +101,32 @@ To build and package a ZIP:
 .\build_and_package_windows.ps1 -Version "0.1.0"
 ```
 
+## Build the macOS app
+
+Install dependencies, build the `.app`, and run its offline runtime smoke test:
+
+```bash
+./install_macos_dependencies.sh
+./build_macos.sh
+```
+
+The local unsigned application is created at:
+
+```text
+dist/VODForge.app
+```
+
+To package an unsigned ZIP for internal testing:
+
+```bash
+./build_and_package_macos.sh 0.1.0
+```
+
+The build bundles FFmpeg, ffprobe, and Deno so a Finder-launched app does not depend on shell `PATH` configuration. Public distribution still requires an Apple Developer ID signature and notarization; the build scripts do not claim or perform those steps.
+
 ## Development
+
+Windows:
 
 ```powershell
 python -m venv .venv
@@ -96,6 +134,15 @@ python -m venv .venv
 python -m pip install -r requirements-dev.txt
 python -m pytest -q
 python -m compileall -q yt_downloader main.py
+```
+
+macOS:
+
+```bash
+./install_macos_dependencies.sh
+.venv/bin/python -m pytest -q
+.venv/bin/python -m compileall -q yt_downloader main.py macos_smoke_test.py
+.venv/bin/python macos_smoke_test.py
 ```
 
 The test suite focuses on export planning, FFmpeg command construction, metadata, path safety, batch parsing, cookie options, diagnostics, and source-format fallbacks.

--- a/build_and_package_macos.sh
+++ b/build_and_package_macos.sh
@@ -4,13 +4,20 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 version="${1:-}"
+export VODFORGE_BUILD_VERSION="${version:-0.1.0-dev}"
 ./build_macos.sh
 
 mkdir -p dist/release
-if [[ -n "$version" ]]; then
-  archive="dist/release/VODForge-macOS-v${version}.zip"
+machine_arch="$(uname -m)"
+if [[ "$machine_arch" == "x86_64" ]]; then
+  release_arch="x64"
 else
-  archive="dist/release/VODForge-macOS.zip"
+  release_arch="$machine_arch"
+fi
+if [[ -n "$version" ]]; then
+  archive="dist/release/VODForge-macOS-${release_arch}-v${version}.zip"
+else
+  archive="dist/release/VODForge-macOS-${release_arch}.zip"
 fi
 rm -f "$archive"
 ditto -c -k --sequesterRsrc --keepParent "dist/VODForge.app" "$archive"

--- a/build_and_package_macos.sh
+++ b/build_and_package_macos.sh
@@ -15,7 +15,11 @@ else
   release_arch="$machine_arch"
 fi
 if [[ -n "$version" ]]; then
-  archive="dist/release/VODForge-macOS-${release_arch}-v${version}.zip"
+  if [[ "${VODFORGE_UNSIGNED_REVIEW:-0}" == "1" ]]; then
+    archive="dist/release/VODForge-macOS-${release_arch}-v${version}-unsigned-review.zip"
+  else
+    archive="dist/release/VODForge-macOS-${release_arch}-v${version}.zip"
+  fi
 else
   archive="dist/release/VODForge-macOS-${release_arch}.zip"
 fi

--- a/build_and_package_macos.sh
+++ b/build_and_package_macos.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+version="${1:-}"
+./build_macos.sh
+
+mkdir -p dist/release
+if [[ -n "$version" ]]; then
+  archive="dist/release/VODForge-macOS-v${version}.zip"
+else
+  archive="dist/release/VODForge-macOS.zip"
+fi
+rm -f "$archive"
+ditto -c -k --sequesterRsrc --keepParent "dist/VODForge.app" "$archive"
+
+echo "Packaged unsigned application: $archive"

--- a/build_and_package_windows.ps1
+++ b/build_and_package_windows.ps1
@@ -5,7 +5,8 @@
 
 param(
   [string]$Version = "",
-  [switch]$PortableOnly
+  [switch]$PortableOnly,
+  [switch]$Sign
 )
 
 $ErrorActionPreference = "Stop"
@@ -19,16 +20,52 @@ if (-not (Test-Path $distDir)) {
   throw "Expected build output not found: $distDir"
 }
 
+function Invoke-VODForgeTrustedSigning {
+  param([Parameter(Mandatory = $true)][string[]]$Files)
+
+  Import-Module TrustedSigning -ErrorAction Stop
+  $params = @{
+    Endpoint = "https://eus.codesigning.azure.net/"
+    CodeSigningAccountName = "Kryden"
+    CertificateProfileName = "kryden-public-signing"
+    Files = ($Files -join ",")
+    FileDigest = "SHA256"
+    TimestampRfc3161 = "http://timestamp.acs.microsoft.com"
+    TimestampDigest = "SHA256"
+    Description = "VODForge"
+    DescriptionUrl = "https://github.com/SnowfallHD/vodforge"
+    ExcludeEnvironmentCredential = $true
+    ExcludeWorkloadIdentityCredential = $true
+    ExcludeManagedIdentityCredential = $true
+    ExcludeSharedTokenCacheCredential = $true
+    ExcludeVisualStudioCredential = $true
+    ExcludeVisualStudioCodeCredential = $true
+    ExcludeAzurePowerShellCredential = $true
+    ExcludeAzureDeveloperCliCredential = $true
+    ExcludeInteractiveBrowserCredential = $true
+  }
+  Invoke-TrustedSigning @params
+  & (Join-Path $PSScriptRoot "verify_windows_signatures.ps1") -Files $Files
+}
+
+if ($Sign) {
+  $applicationExe = Join-Path $distDir "VODForge.exe"
+  Invoke-VODForgeTrustedSigning -Files @($applicationExe)
+}
+
+if (-not $PortableOnly) {
+  & (Join-Path $PSScriptRoot "build_windows_installer.ps1") -Version $env:VODFORGE_BUILD_VERSION
+  if ($Sign) {
+    $installer = Join-Path $PSScriptRoot "dist\release\VODForge-Windows-Setup-v$($env:VODFORGE_BUILD_VERSION).exe"
+    Invoke-VODForgeTrustedSigning -Files @($installer)
+  }
+}
+
 $releaseDir = Join-Path $PSScriptRoot "dist\release"
 New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
-
 $name = if ($Version) { "VODForge-Windows-Portable-v$Version.zip" } else { "VODForge-Windows-Portable.zip" }
 $zip = Join-Path $releaseDir $name
 Remove-Item $zip -Force -ErrorAction SilentlyContinue
 Compress-Archive -Path $distDir -DestinationPath $zip -Force
 
 Write-Host "Packaged portable app: $zip"
-
-if (-not $PortableOnly) {
-  & (Join-Path $PSScriptRoot "build_windows_installer.ps1") -Version $env:VODFORGE_BUILD_VERSION
-}

--- a/build_and_package_windows.ps1
+++ b/build_and_package_windows.ps1
@@ -4,12 +4,14 @@
 #   .\build_and_package_windows.ps1 -Version "0.1.0"
 
 param(
-  [string]$Version = ""
+  [string]$Version = "",
+  [switch]$PortableOnly
 )
 
 $ErrorActionPreference = "Stop"
 Set-Location $PSScriptRoot
 
+$env:VODFORGE_BUILD_VERSION = if ($Version) { $Version } else { "0.1.0-dev" }
 & (Join-Path $PSScriptRoot "build_windows.ps1")
 
 $distDir = Join-Path $PSScriptRoot "dist\VODForge"
@@ -20,9 +22,13 @@ if (-not (Test-Path $distDir)) {
 $releaseDir = Join-Path $PSScriptRoot "dist\release"
 New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
 
-$name = if ($Version) { "VODForge-Windows-v$Version.zip" } else { "VODForge-Windows.zip" }
+$name = if ($Version) { "VODForge-Windows-Portable-v$Version.zip" } else { "VODForge-Windows-Portable.zip" }
 $zip = Join-Path $releaseDir $name
 Remove-Item $zip -Force -ErrorAction SilentlyContinue
 Compress-Archive -Path $distDir -DestinationPath $zip -Force
 
-Write-Host "Packaged runnable app: $zip"
+Write-Host "Packaged portable app: $zip"
+
+if (-not $PortableOnly) {
+  & (Join-Path $PSScriptRoot "build_windows_installer.ps1") -Version $env:VODFORGE_BUILD_VERSION
+}

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -39,6 +39,16 @@ fi
 "$python_bin" -m compileall -q yt_downloader main.py macos_smoke_test.py
 "$python_bin" -m pytest -q
 
+build_version="${VODFORGE_BUILD_VERSION:-0.1.0-dev}"
+if [[ ! "$build_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "VODFORGE_BUILD_VERSION must use semantic versioning, for example 1.2.3."
+  exit 1
+fi
+build_version_dir="build/version"
+mkdir -p "$build_version_dir"
+build_version_file="$build_version_dir/VODFORGE_VERSION"
+printf '%s' "$build_version" > "$build_version_file"
+
 ffmpeg="$(command -v ffmpeg || true)"
 ffprobe="$(command -v ffprobe || true)"
 deno="$(command -v deno || true)"
@@ -55,6 +65,7 @@ fi
   --onedir \
   --name "VODForge" \
   --osx-bundle-identifier "com.snowfallhd.vodforge" \
+  --add-data "$build_version_file:." \
   --add-binary "$ffmpeg:." \
   --add-binary "$ffprobe:." \
   --add-binary "$deno:." \
@@ -67,5 +78,5 @@ if [[ ! -x "$app_binary" ]]; then
 fi
 
 "$app_binary" --runtime-smoke
-echo "Built unsigned local application: dist/VODForge.app"
+echo "Built unsigned local VODForge v${build_version}: dist/VODForge.app"
 echo "Developer ID signing and notarization are still required before public distribution."

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "The macOS application must be built on macOS."
+  exit 1
+fi
+
+python_bin="${VODFORGE_PYTHON:-}"
+if [[ -z "$python_bin" && -x ".venv/bin/python" ]]; then
+  python_bin=".venv/bin/python"
+fi
+if [[ -z "$python_bin" ]] && command -v python3.13 >/dev/null 2>&1; then
+  python_bin="$(command -v python3.13)"
+fi
+if [[ -z "$python_bin" && -x "/opt/homebrew/opt/python@3.13/bin/python3.13" ]]; then
+  python_bin="/opt/homebrew/opt/python@3.13/bin/python3.13"
+fi
+if [[ -z "$python_bin" ]]; then
+  echo "Python 3.13 with Tk was not found. Run ./install_macos_dependencies.sh first."
+  exit 1
+fi
+
+if ! "$python_bin" -c 'import tkinter' >/dev/null 2>&1; then
+  echo "The selected Python does not include Tk: $python_bin"
+  echo "Run ./install_macos_dependencies.sh or set VODFORGE_PYTHON to a Tk-enabled Python 3.11+."
+  exit 1
+fi
+
+if [[ "$python_bin" != ".venv/bin/python" ]]; then
+  "$python_bin" -m venv .venv
+  python_bin=".venv/bin/python"
+fi
+
+"$python_bin" -m pip install --upgrade pip
+"$python_bin" -m pip install -r requirements-dev.txt
+"$python_bin" -m compileall -q yt_downloader main.py macos_smoke_test.py
+"$python_bin" -m pytest -q
+
+ffmpeg="$(command -v ffmpeg || true)"
+ffprobe="$(command -v ffprobe || true)"
+deno="$(command -v deno || true)"
+if [[ -z "$ffmpeg" || -z "$ffprobe" || -z "$deno" ]]; then
+  echo "FFmpeg, ffprobe, and Deno are required for a self-contained app."
+  echo "Run ./install_macos_dependencies.sh first."
+  exit 1
+fi
+
+"$python_bin" -m PyInstaller \
+  --noconfirm \
+  --clean \
+  --windowed \
+  --onedir \
+  --name "VODForge" \
+  --osx-bundle-identifier "com.snowfallhd.vodforge" \
+  --add-binary "$ffmpeg:." \
+  --add-binary "$ffprobe:." \
+  --add-binary "$deno:." \
+  main.py
+
+app_binary="dist/VODForge.app/Contents/MacOS/VODForge"
+if [[ ! -x "$app_binary" ]]; then
+  echo "Expected application executable was not created: $app_binary"
+  exit 1
+fi
+
+"$app_binary" --runtime-smoke
+echo "Built unsigned local application: dist/VODForge.app"
+echo "Developer ID signing and notarization are still required before public distribution."

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -14,6 +14,16 @@ python -m venv .venv
 python -m pip install --upgrade pip
 python -m pip install -r requirements-dev.txt
 
+$buildVersion = if ($env:VODFORGE_BUILD_VERSION) { $env:VODFORGE_BUILD_VERSION } else { "0.1.0-dev" }
+if ($buildVersion -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+  throw "VODFORGE_BUILD_VERSION must use semantic versioning, for example 1.2.3."
+}
+$buildMetadataDir = Join-Path $PSScriptRoot "build\version"
+New-Item -ItemType Directory -Force -Path $buildMetadataDir | Out-Null
+$buildVersionFile = Join-Path $buildMetadataDir "VODFORGE_VERSION"
+Set-Content -Path $buildVersionFile -Value $buildVersion -NoNewline
+$addData = @("--add-data", "$buildVersionFile;.")
+
 # Bundle FFmpeg. Prefer explicit vendor copies because embedding thumbnails also
 # needs ffprobe.exe. imageio-ffmpeg is only a fallback for non-thumbnail flows.
 $addBinary = @()
@@ -53,7 +63,8 @@ python -m PyInstaller `
   --clean `
   --windowed `
   --name "VODForge" `
+  @addData `
   @addBinary `
   main.py
 
-Write-Host "Built: dist\VODForge\VODForge.exe"
+Write-Host "Built VODForge v$buildVersion`: dist\VODForge\VODForge.exe"

--- a/build_windows_installer.ps1
+++ b/build_windows_installer.ps1
@@ -1,0 +1,41 @@
+# Packages the built onedir application as a per-user Windows installer.
+# Inno Setup keeps VODForge.exe and _internal together under LocalAppData so
+# users never need to manage the runtime folder by hand.
+
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Version
+)
+
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
+
+if ($Version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+  throw "Version must use semantic versioning, for example 1.2.3."
+}
+
+$iscc = Get-Command ISCC.exe -ErrorAction SilentlyContinue
+if (-not $iscc) {
+  $standardPaths = @(
+    "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+    "$env:ProgramFiles\Inno Setup 6\ISCC.exe"
+  )
+  $isccPath = $standardPaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+} else {
+  $isccPath = $iscc.Source
+}
+if (-not $isccPath) {
+  throw "Inno Setup 6 was not found. Install it or use -PortableOnly to create only the portable ZIP."
+}
+
+$appExe = Join-Path $PSScriptRoot "dist\VODForge\VODForge.exe"
+if (-not (Test-Path $appExe)) {
+  throw "Expected VODForge build not found: $appExe"
+}
+
+& $isccPath "/DMyAppVersion=$Version" (Join-Path $PSScriptRoot "installer_windows.iss")
+if ($LASTEXITCODE -ne 0) {
+  throw "Inno Setup failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Packaged per-user installer in dist\release."

--- a/finalize_macos_release.sh
+++ b/finalize_macos_release.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+version="${1:-}"
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Usage: ./finalize_macos_release.sh 1.2.3"
+  exit 1
+fi
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Release finalization must run on the signing Mac."
+  exit 1
+fi
+if [[ "$(git branch --show-current)" != "main" ]]; then
+  echo "Release finalization must run from main."
+  exit 1
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Release finalization requires a clean worktree."
+  exit 1
+fi
+
+repo="SnowfallHD/vodforge"
+tag="v${version}"
+head_sha="$(git rev-parse HEAD)"
+release_json="$(gh release view "$tag" --repo "$repo" --json isDraft,targetCommitish)"
+if [[ "$(plutil -extract isDraft raw -o - - <<<"$release_json")" != "true" ]]; then
+  echo "The release must still be a draft: $tag"
+  exit 1
+fi
+if [[ "$(plutil -extract targetCommitish raw -o - - <<<"$release_json")" != "$head_sha" ]]; then
+  echo "The draft release does not target current main: $head_sha"
+  exit 1
+fi
+
+finalize_dir="$(mktemp -d "${TMPDIR:-/tmp}/vodforge-release-${version}.XXXXXX")"
+cleanup() {
+  rm -rf "$finalize_dir"
+}
+trap cleanup EXIT
+
+arm_unsigned="VODForge-macOS-arm64-v${version}-unsigned-review.zip"
+x64_unsigned="VODForge-macOS-x64-v${version}-unsigned-review.zip"
+windows_installer="VODForge-Windows-Setup-v${version}.exe"
+windows_portable="VODForge-Windows-Portable-v${version}.zip"
+
+gh release download "$tag" --repo "$repo" --dir "$finalize_dir" \
+  --pattern "$arm_unsigned" \
+  --pattern "$x64_unsigned" \
+  --pattern "$windows_installer" \
+  --pattern "$windows_portable"
+
+for arch in arm64 x64; do
+  unsigned_name="VODForge-macOS-${arch}-v${version}-unsigned-review.zip"
+  signed_name="VODForge-macOS-${arch}-v${version}.zip"
+  extract_dir="$finalize_dir/${arch}"
+  mkdir -p "$extract_dir"
+  ditto -x -k "$finalize_dir/$unsigned_name" "$extract_dir"
+  app_path="$extract_dir/VODForge.app"
+  if [[ ! -d "$app_path" ]]; then
+    echo "Expected VODForge.app was not found in $unsigned_name"
+    exit 1
+  fi
+  ./sign_and_notarize_macos.sh "$app_path" "$finalize_dir/$signed_name"
+  if [[ "$arch" == "arm64" ]]; then
+    "$app_path/Contents/MacOS/VODForge" --runtime-smoke
+  else
+    arch -x86_64 "$app_path/Contents/MacOS/VODForge" --runtime-smoke
+  fi
+done
+
+(
+  cd "$finalize_dir"
+  shasum -a 256 \
+    "$windows_installer" \
+    "$windows_portable" \
+    "VODForge-macOS-arm64-v${version}.zip" \
+    "VODForge-macOS-x64-v${version}.zip" \
+    | sort -k2 > SHA256SUMS.txt
+)
+
+gh release upload "$tag" --repo "$repo" --clobber \
+  "$finalize_dir/VODForge-macOS-arm64-v${version}.zip" \
+  "$finalize_dir/VODForge-macOS-x64-v${version}.zip" \
+  "$finalize_dir/SHA256SUMS.txt"
+gh release delete-asset "$tag" "$arm_unsigned" --repo "$repo" --yes
+gh release delete-asset "$tag" "$x64_unsigned" --repo "$repo" --yes
+
+echo "Final signed artifacts and checksums uploaded to draft release $tag."
+echo "Review the release assets and checksums before publishing."

--- a/install_macos_dependencies.sh
+++ b/install_macos_dependencies.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This installer is for macOS."
+  exit 1
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required. Install it from https://brew.sh and run this script again."
+  exit 1
+fi
+
+echo "Installing the macOS Python/Tk runtime, FFmpeg, and Deno..."
+brew install python@3.13 python-tk@3.13 ffmpeg deno
+
+python_bin="$(brew --prefix python@3.13)/bin/python3.13"
+if [[ ! -x "$python_bin" ]]; then
+  echo "Homebrew Python 3.13 was not found at $python_bin"
+  exit 1
+fi
+
+"$python_bin" -c 'import tkinter; print(f"Tk {tkinter.TkVersion} ready")'
+"$python_bin" -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r requirements-dev.txt
+
+echo "macOS dependencies are ready. Run: .venv/bin/python main.py"

--- a/installer_windows.iss
+++ b/installer_windows.iss
@@ -1,0 +1,45 @@
+#ifndef MyAppVersion
+  #define MyAppVersion "0.1.0-dev"
+#endif
+
+#define MyAppName "VODForge"
+#define MyAppPublisher "SnowfallHD"
+#define MyAppURL "https://github.com/SnowfallHD/vodforge"
+#define MyAppExeName "VODForge.exe"
+
+[Setup]
+AppId={{2C217998-2315-41E3-99BA-3A0289331B54}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={localappdata}\Programs\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+OutputDir=dist\release
+OutputBaseFilename=VODForge-Windows-Setup-v{#MyAppVersion}
+Compression=lzma2
+SolidCompression=yes
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+UninstallDisplayIcon={app}\{#MyAppExeName}
+CloseApplications=yes
+RestartApplications=yes
+CloseApplicationsFilter={#MyAppExeName}
+WizardStyle=modern
+
+[Files]
+Source: "dist\VODForge\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; Flags: nowait postinstall skipifsilent

--- a/macos_smoke_test.py
+++ b/macos_smoke_test.py
@@ -1,0 +1,14 @@
+import sys
+
+from yt_downloader.app import runtime_smoke
+
+
+def main() -> int:
+    if sys.platform != "darwin":
+        print("macos_smoke_test.py must run on macOS")
+        return 1
+    return runtime_smoke()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sign_and_notarize_macos.sh
+++ b/sign_and_notarize_macos.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "macOS signing and notarization must run on macOS."
+  exit 1
+fi
+
+app_path="${1:-}"
+archive_path="${2:-}"
+identity="${VODFORGE_MACOS_SIGN_IDENTITY:-Developer ID Application: Kryden Ventures, LLC (76G5W4954G)}"
+notary_profile="${VODFORGE_NOTARY_PROFILE:-kryden}"
+
+if [[ -z "$app_path" || -z "$archive_path" ]]; then
+  echo "Usage: ./sign_and_notarize_macos.sh path/to/VODForge.app path/to/release.zip"
+  exit 1
+fi
+if [[ ! -d "$app_path" || "$app_path" != *.app ]]; then
+  echo "Expected an application bundle: $app_path"
+  exit 1
+fi
+if [[ "$archive_path" != *.zip ]]; then
+  echo "The release archive must use a .zip extension: $archive_path"
+  exit 1
+fi
+if ! security find-identity -v -p codesigning | grep -Fq "\"$identity\""; then
+  echo "Developer ID signing identity is unavailable: $identity"
+  exit 1
+fi
+if ! xcrun notarytool history --keychain-profile "$notary_profile" --output-format json >/dev/null; then
+  echo "Notarization keychain profile is unavailable: $notary_profile"
+  exit 1
+fi
+
+codesign --force --deep --strict --options runtime --timestamp --sign "$identity" "$app_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+
+notary_dir="$(mktemp -d "${TMPDIR:-/tmp}/vodforge-notary.XXXXXX")"
+cleanup() {
+  rm -rf "$notary_dir"
+}
+trap cleanup EXIT
+
+notary_archive="$notary_dir/VODForge-notary.zip"
+ditto -c -k --sequesterRsrc --keepParent "$app_path" "$notary_archive"
+notary_result="$notary_dir/notary-result.json"
+xcrun notarytool submit "$notary_archive" \
+  --keychain-profile "$notary_profile" \
+  --wait \
+  --output-format json > "$notary_result"
+
+notary_status="$(plutil -extract status raw -o - "$notary_result")"
+if [[ "$notary_status" != "Accepted" ]]; then
+  submission_id="$(plutil -extract id raw -o - "$notary_result" 2>/dev/null || true)"
+  if [[ -n "$submission_id" ]]; then
+    xcrun notarytool log "$submission_id" --keychain-profile "$notary_profile" || true
+  fi
+  echo "Apple notarization was not accepted: $notary_status"
+  exit 1
+fi
+
+xcrun stapler staple "$app_path"
+xcrun stapler validate "$app_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+spctl --assess --type execute --verbose=2 "$app_path"
+
+mkdir -p "$(dirname "$archive_path")"
+rm -f "$archive_path"
+ditto -c -k --sequesterRsrc --keepParent "$app_path" "$archive_path"
+echo "Signed, notarized, stapled, and packaged application: $archive_path"

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from yt_downloader.history import (
+    HistoryError,
+    application_data_dir,
+    history_identity,
+    history_output_dir,
+    load_history,
+    save_history,
+    sanitize_history_record,
+    upsert_history,
+)
+
+
+def test_application_data_dir_uses_platform_conventions(tmp_path: Path):
+    assert application_data_dir(platform_name="darwin", home=tmp_path) == tmp_path / "Library" / "Application Support" / "VODForge"
+    assert application_data_dir(platform_name="win32", home=tmp_path, local_app_data="C:/Users/Test/AppData/Local") == Path(
+        "C:/Users/Test/AppData/Local/VODForge"
+    )
+    assert application_data_dir(platform_name="linux", home=tmp_path, xdg_data_home=None) == tmp_path / ".local" / "share" / "vodforge"
+
+
+def test_sanitize_history_record_allowlists_metadata_and_excludes_secrets(tmp_path: Path):
+    record = sanitize_history_record(
+        {
+            "id": "abc123",
+            "title": "Example",
+            "description": "Description",
+            "duration": 42,
+            "uploader": "Creator",
+            "tags": ["one", "one", "two"],
+            "cookiefile": "/private/cookies.txt",
+            "http_headers": {"Authorization": "secret"},
+            "password": "secret",
+        },
+        tmp_path / "downloads" / "Example",
+        recorded_at="2026-08-05T12:00:00+00:00",
+    )
+
+    assert record["id"] == "abc123"
+    assert record["tags"] == ["one", "two"]
+    assert history_output_dir(record) == (tmp_path / "downloads" / "Example").resolve()
+    assert record["vodforge_recorded_at"] == "2026-08-05T12:00:00+00:00"
+    assert "cookiefile" not in record
+    assert "http_headers" not in record
+    assert "password" not in record
+
+
+def test_history_round_trip_and_redownload_deduplication(tmp_path: Path):
+    location = tmp_path / "downloads" / "Example"
+    history = upsert_history([], {"id": "abc123", "title": "Original"}, location, recorded_at="2026-08-05T12:00:00+00:00")
+    history = upsert_history(history, {"id": "abc123", "title": "Updated"}, location, recorded_at="2026-08-05T13:00:00+00:00")
+    history = upsert_history(history, {"id": "xyz789", "title": "Second"}, tmp_path / "other", recorded_at="2026-08-05T14:00:00+00:00")
+
+    assert [item["id"] for item in history] == ["xyz789", "abc123"]
+    assert history[1]["title"] == "Updated"
+
+    path = tmp_path / "state" / "download-history.json"
+    save_history(path, history)
+    loaded = load_history(path)
+
+    assert loaded == history
+    assert json.loads(path.read_text(encoding="utf-8"))["schema_version"] == 1
+    assert history_identity(loaded[0]) == history_identity(history[0])
+
+
+def test_history_keeps_same_video_downloaded_to_two_locations(tmp_path: Path):
+    first = upsert_history([], {"id": "abc123", "title": "Example"}, tmp_path / "one")
+    second = upsert_history(first, {"id": "abc123", "title": "Example"}, tmp_path / "two")
+
+    assert len(second) == 2
+    assert history_output_dir(second[0]) != history_output_dir(second[1])
+
+
+def test_invalid_history_is_reported_without_overwriting_source(tmp_path: Path):
+    path = tmp_path / "download-history.json"
+    path.write_text("not json", encoding="utf-8")
+
+    with pytest.raises(HistoryError, match="could not read"):
+        load_history(path)
+
+    assert path.read_text(encoding="utf-8") == "not json"

--- a/tests/test_metadata_helpers.py
+++ b/tests/test_metadata_helpers.py
@@ -106,6 +106,7 @@ def test_windows_runtime_candidates_keep_exe_compatibility():
 def test_ytdlp_ffmpeg_location_uses_parent_for_standard_executable_names():
     assert ytdlp_ffmpeg_location("/opt/homebrew/bin/ffmpeg") == "/opt/homebrew/bin"
     assert ytdlp_ffmpeg_location("C:/vendor/ffmpeg.exe") == "C:/vendor"
+    assert ytdlp_ffmpeg_location(r"C:\vendor\ffmpeg.exe") == r"C:\vendor"
     assert ytdlp_ffmpeg_location("/bundle/ffmpeg-custom") == "/bundle/ffmpeg-custom"
 
 

--- a/tests/test_metadata_helpers.py
+++ b/tests/test_metadata_helpers.py
@@ -41,18 +41,78 @@ from yt_downloader.app import (
     best_thumbnail_for_download,
     format_ytdlp_user_error,
     parse_url_list_text,
+    diagnostics_dir,
+    platform_font_families,
     prepare_batch_item_url,
     playlist_folder_name,
     run_ffprobe_json,
+    runtime_version_command,
     save_thumbnail_image,
     staging_output_template,
     transcode_temp_paths,
     transcode_to_vod_streaming_settings,
+    runtime_executable_candidates,
     video_list_row_values,
     video_file_name,
     video_output_dir,
+    ytdlp_ffmpeg_location,
     write_compact_video_metadata,
 )
+
+
+def test_platform_diagnostics_paths_follow_native_conventions(tmp_path: Path):
+    assert diagnostics_dir(platform_name="darwin", home=tmp_path) == tmp_path / "Library" / "Logs" / "VODForge"
+    assert diagnostics_dir(platform_name="linux", home=tmp_path) == tmp_path / ".vodforge" / "logs"
+    assert diagnostics_dir(platform_name="win32", home=tmp_path, local_app_data="C:/Users/Test/AppData/Local") == (
+        Path("C:/Users/Test/AppData/Local") / "VODForge" / "logs"
+    )
+
+
+def test_platform_fonts_use_macos_and_windows_system_families():
+    assert platform_font_families("darwin") == ("Helvetica Neue", "Menlo")
+    assert platform_font_families("win32") == ("Segoe UI", "Cascadia Mono")
+    assert platform_font_families("linux") == ("TkDefaultFont", "TkFixedFont")
+
+
+def test_macos_runtime_candidates_cover_bundle_vendor_and_homebrew_paths():
+    candidates = runtime_executable_candidates(
+        "ffmpeg",
+        platform_name="darwin",
+        frozen=True,
+        executable=Path("/Applications/VODForge.app/Contents/MacOS/VODForge"),
+        meipass=Path("/Applications/VODForge.app/Contents/Frameworks"),
+        repo_root=Path("/source/vodforge"),
+    )
+
+    assert Path("/Applications/VODForge.app/Contents/MacOS/ffmpeg") in candidates
+    assert Path("/Applications/VODForge.app/Contents/Frameworks/ffmpeg") in candidates
+    assert Path("/source/vodforge/vendor/ffmpeg/bin/ffmpeg") in candidates
+    assert Path("/opt/homebrew/bin/ffmpeg") in candidates
+    assert Path("/usr/local/bin/ffmpeg") in candidates
+
+
+def test_windows_runtime_candidates_keep_exe_compatibility():
+    candidates = runtime_executable_candidates(
+        "deno",
+        platform_name="win32",
+        frozen=False,
+        repo_root=Path("C:/source/vodforge"),
+    )
+
+    assert candidates[0] == Path("C:/source/vodforge/deno.exe")
+    assert Path("C:/source/vodforge/vendor/deno/deno.exe") in candidates
+
+
+def test_ytdlp_ffmpeg_location_uses_parent_for_standard_executable_names():
+    assert ytdlp_ffmpeg_location("/opt/homebrew/bin/ffmpeg") == "/opt/homebrew/bin"
+    assert ytdlp_ffmpeg_location("C:/vendor/ffmpeg.exe") == "C:/vendor"
+    assert ytdlp_ffmpeg_location("/bundle/ffmpeg-custom") == "/bundle/ffmpeg-custom"
+
+
+def test_runtime_version_commands_use_each_tool_cli_contract():
+    assert runtime_version_command("ffmpeg", "/bundle/ffmpeg") == ["/bundle/ffmpeg", "-version"]
+    assert runtime_version_command("ffprobe", "/bundle/ffprobe") == ["/bundle/ffprobe", "-version"]
+    assert runtime_version_command("deno", "/bundle/deno") == ["/bundle/deno", "--version"]
 
 
 def test_build_tags_display_text_uses_comma_space_for_copying():

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_workflow_signs_before_packaging_windows_portable_archive():
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    app_sign = workflow.index("name: Sign packaged Windows application")
+    installer_build = workflow.index("name: Build Windows installer")
+    installer_sign = workflow.index("name: Sign Windows installer")
+    portable_package = workflow.index("Compress-Archive")
+
+    assert app_sign < installer_build < installer_sign < portable_package
+    assert "azure/login@v3" in workflow
+    assert "azure/artifact-signing-action@v2" in workflow
+    assert "verify_windows_signatures.ps1" in workflow
+
+
+def test_release_workflow_keeps_macos_artifacts_explicitly_review_only():
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    assert "vodforge-macos-${{ matrix.architecture }}-unsigned" in workflow
+    assert 'VODFORGE_UNSIGNED_REVIEW: "1"' in workflow
+    assert "Do not publish the draft until both macOS architectures" in workflow
+
+
+def test_macos_release_script_requires_accepted_notarization_and_stapling():
+    script = (ROOT / "sign_and_notarize_macos.sh").read_text()
+
+    assert 'notary_status" != "Accepted"' in script
+    assert "stapler staple" in script
+    assert "stapler validate" in script
+    assert "spctl --assess" in script
+
+
+def test_release_finalizer_replaces_unsigned_reviews_and_regenerates_checksums():
+    script = (ROOT / "finalize_macos_release.sh").read_text()
+
+    assert "Release finalization must run from main" in script
+    assert "unsigned-review.zip" in script
+    assert "sign_and_notarize_macos.sh" in script
+    assert "SHA256SUMS.txt" in script
+    assert "release delete-asset" in script

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+
+import pytest
+
+from yt_downloader.updates import (
+    ReleaseAsset,
+    ReleaseInfo,
+    download_verified_update,
+    is_newer_release,
+    parse_release_payload,
+    parse_sha256sums,
+    release_asset_for_platform,
+    semantic_version_key,
+)
+from yt_downloader.version import DEFAULT_VERSION, read_app_version
+
+
+def test_semantic_versions_treat_stable_release_as_newer_than_dev_build():
+    assert semantic_version_key("v1.2.3") > semantic_version_key("1.2.3-dev")
+    assert is_newer_release("0.1.0-dev", "v0.1.0")
+    assert not is_newer_release("0.2.0", "v0.1.9")
+
+
+def test_release_payload_accepts_only_public_stable_github_release():
+    release = parse_release_payload(
+        {
+            "tag_name": "v1.2.3",
+            "name": "VODForge 1.2.3",
+            "html_url": "https://github.com/SnowfallHD/vodforge/releases/tag/v1.2.3",
+            "body": "Release notes",
+            "draft": False,
+            "prerelease": False,
+            "assets": [
+                {
+                    "name": "VODForge-Windows-Setup-v1.2.3.exe",
+                    "browser_download_url": "https://github.com/SnowfallHD/vodforge/releases/download/v1.2.3/VODForge-Windows-Setup-v1.2.3.exe",
+                    "size": 123,
+                }
+            ],
+        }
+    )
+
+    assert release.version == "1.2.3"
+    assert release.tag_name == "v1.2.3"
+    assert release.assets[0].size == 123
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tag_name": "v1.2.3", "html_url": "https://evil.example/release", "draft": False, "prerelease": False},
+        {"tag_name": "latest", "html_url": "https://github.com/SnowfallHD/vodforge/releases/latest", "draft": False, "prerelease": False},
+        {"tag_name": "v1.2.3-beta.1", "html_url": "https://github.com/SnowfallHD/vodforge/releases/tag/v1.2.3-beta.1", "draft": False, "prerelease": False},
+        {"tag_name": "v1.2.3", "html_url": "https://github.com/SnowfallHD/vodforge/releases/tag/v1.2.3", "draft": True, "prerelease": False},
+    ],
+)
+def test_release_payload_rejects_untrusted_or_nonstable_data(payload: dict[str, object]):
+    with pytest.raises(ValueError):
+        parse_release_payload(payload)
+
+
+def test_packaged_version_file_is_validated(tmp_path: Path):
+    version_file = tmp_path / "VODFORGE_VERSION"
+    version_file.write_text("1.4.2\n", encoding="utf-8")
+    assert read_app_version(version_file) == "1.4.2"
+
+    version_file.write_text("not-a-version", encoding="utf-8")
+    assert read_app_version(version_file) == DEFAULT_VERSION
+
+
+def test_platform_asset_selection_is_exact():
+    release = ReleaseInfo(
+        version="1.2.3",
+        tag_name="v1.2.3",
+        name="VODForge 1.2.3",
+        html_url="https://github.com/SnowfallHD/vodforge/releases/tag/v1.2.3",
+        notes="",
+        assets=(
+            ReleaseAsset("VODForge-Windows-Setup-v1.2.3.exe", "https://github.com/example/windows", 10),
+            ReleaseAsset("VODForge-macOS-arm64-v1.2.3.zip", "https://github.com/example/mac-arm", 10),
+            ReleaseAsset("VODForge-macOS-x64-v1.2.3.zip", "https://github.com/example/mac-x64", 10),
+        ),
+    )
+
+    assert release_asset_for_platform(release, platform_name="win32", machine="AMD64").name.endswith(".exe")
+    assert release_asset_for_platform(release, platform_name="darwin", machine="arm64").name == "VODForge-macOS-arm64-v1.2.3.zip"
+    assert release_asset_for_platform(release, platform_name="darwin", machine="x86_64").name == "VODForge-macOS-x64-v1.2.3.zip"
+    assert release_asset_for_platform(release, platform_name="linux", machine="x86_64") is None
+
+
+def test_verified_update_requires_matching_checksum(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    update_bytes = b"verified installer bytes"
+    digest = hashlib.sha256(update_bytes).hexdigest()
+    asset_name = "VODForge-Windows-Setup-v1.2.3.exe"
+    release = ReleaseInfo(
+        version="1.2.3",
+        tag_name="v1.2.3",
+        name="VODForge 1.2.3",
+        html_url="https://github.com/SnowfallHD/vodforge/releases/tag/v1.2.3",
+        notes="",
+        assets=(
+            ReleaseAsset(asset_name, "https://github.com/example/update", len(update_bytes)),
+            ReleaseAsset("SHA256SUMS.txt", "https://github.com/example/checksums", 80),
+        ),
+    )
+
+    class FakeResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+
+    def fake_urlopen(request, timeout=0):
+        assert timeout == 60
+        if request.full_url.endswith("checksums"):
+            return FakeResponse(f"{digest}  {asset_name}\n".encode())
+        return FakeResponse(update_bytes)
+
+    monkeypatch.setattr("yt_downloader.updates.urllib.request.urlopen", fake_urlopen)
+    output = download_verified_update(release, tmp_path, platform_name="win32", machine="AMD64")
+
+    assert output.read_bytes() == update_bytes
+    assert parse_sha256sums(f"{digest}  {asset_name}\n") == {asset_name: digest}
+
+
+def test_verified_update_deletes_tampered_partial_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    asset_name = "VODForge-Windows-Setup-v1.2.3.exe"
+    release = ReleaseInfo(
+        version="1.2.3",
+        tag_name="v1.2.3",
+        name="VODForge 1.2.3",
+        html_url="https://github.com/SnowfallHD/vodforge/releases/tag/v1.2.3",
+        notes="",
+        assets=(
+            ReleaseAsset(asset_name, "https://github.com/example/update", 8),
+            ReleaseAsset("SHA256SUMS.txt", "https://github.com/example/checksums", 80),
+        ),
+    )
+
+    class FakeResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+
+    responses = iter([FakeResponse(f"{'0' * 64}  {asset_name}\n".encode()), FakeResponse(b"tampered")])
+    monkeypatch.setattr("yt_downloader.updates.urllib.request.urlopen", lambda *_args, **_kwargs: next(responses))
+
+    with pytest.raises(RuntimeError, match="SHA-256 verification"):
+        download_verified_update(release, tmp_path, platform_name="win32", machine="AMD64")
+
+    assert not (tmp_path / asset_name).exists()
+    assert not (tmp_path / f"{asset_name}.part").exists()

--- a/verify_windows_signatures.ps1
+++ b/verify_windows_signatures.ps1
@@ -1,0 +1,27 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string[]]$Files
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $Files) {
+  throw "At least one file is required for Authenticode verification."
+}
+
+foreach ($file in $Files) {
+  if (-not (Test-Path -LiteralPath $file -PathType Leaf)) {
+    throw "Signed file was not found: $file"
+  }
+  $signature = Get-AuthenticodeSignature -LiteralPath $file
+  if ($signature.Status -ne "Valid") {
+    throw "Authenticode verification failed for $file`: $($signature.Status) $($signature.StatusMessage)"
+  }
+  if ($signature.SignerCertificate.Subject -notlike '*O="Kryden Ventures, LLC"*') {
+    throw "Unexpected Authenticode publisher for $file`: $($signature.SignerCertificate.Subject)"
+  }
+  if (-not $signature.TimeStamperCertificate) {
+    throw "The Authenticode signature is missing a trusted timestamp: $file"
+  }
+  Write-Host "Verified Authenticode signature: $file"
+}

--- a/yt_downloader/app.py
+++ b/yt_downloader/app.py
@@ -135,9 +135,11 @@ def runtime_executable_candidates(
 
     directories: list[Path] = []
     if frozen:
-        directories.append(executable.resolve().parent)
+        # Keep the caller's path semantics intact. Resolving a simulated macOS
+        # bundle path on a Windows test host incorrectly prefixes its drive.
+        directories.append(executable.parent)
         if meipass is not None:
-            directories.append(meipass.resolve())
+            directories.append(meipass)
     directories.append(repo_root)
     if tool_name in {"ffmpeg", "ffprobe"}:
         directories.append(repo_root / "vendor" / "ffmpeg" / "bin")
@@ -172,10 +174,14 @@ def find_runtime_executable(tool_name: str) -> str | None:
 
 def ytdlp_ffmpeg_location(ffmpeg: str) -> str:
     """Point yt-dlp at an FFmpeg directory when the executable has a standard name."""
-    ffmpeg_path = Path(ffmpeg)
-    if ffmpeg_path.name.lower() in {"ffmpeg", "ffmpeg.exe"}:
-        return str(ffmpeg_path.parent)
-    return str(ffmpeg_path)
+    normalized = ffmpeg.replace("\\", "/")
+    name = normalized.rsplit("/", 1)[-1]
+    if name.lower() not in {"ffmpeg", "ffmpeg.exe"}:
+        return ffmpeg
+    parent = normalized.rsplit("/", 1)[0] if "/" in normalized else "."
+    if "\\" in ffmpeg and "/" not in ffmpeg:
+        return parent.replace("/", "\\")
+    return parent
 
 
 def runtime_version_command(tool_name: str, executable: str) -> list[str]:

--- a/yt_downloader/app.py
+++ b/yt_downloader/app.py
@@ -68,11 +68,121 @@ BACKEND_TEMP_OUTPUT_NAME = "__vodforge-tmp.mp4"
 BACKEND_ORIGINAL_BACKUP_NAME = "__vodforge-original.mp4"
 
 
-def diagnostics_dir() -> Path:
-    base = os.environ.get("LOCALAPPDATA")
-    if base:
-        return Path(base) / APP_NAME / "logs"
-    return Path.home() / ".vodforge" / "logs"
+def diagnostics_dir(
+    *,
+    platform_name: str | None = None,
+    home: Path | None = None,
+    local_app_data: str | None = None,
+) -> Path:
+    """Return the platform's conventional per-user diagnostics directory."""
+    platform_name = sys.platform if platform_name is None else platform_name
+    home = Path.home() if home is None else home
+    if platform_name.startswith("win"):
+        base = local_app_data if local_app_data is not None else os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / APP_NAME / "logs"
+    if platform_name == "darwin":
+        return home / "Library" / "Logs" / APP_NAME
+    return home / ".vodforge" / "logs"
+
+
+def platform_font_families(platform_name: str | None = None) -> tuple[str, str]:
+    platform_name = sys.platform if platform_name is None else platform_name
+    if platform_name == "darwin":
+        return "Helvetica Neue", "Menlo"
+    if platform_name.startswith("win"):
+        return "Segoe UI", "Cascadia Mono"
+    return "TkDefaultFont", "TkFixedFont"
+
+
+def runtime_executable_candidates(
+    tool_name: str,
+    *,
+    platform_name: str | None = None,
+    frozen: bool | None = None,
+    executable: Path | None = None,
+    meipass: Path | None = None,
+    repo_root: Path | None = None,
+) -> list[Path]:
+    """Return deterministic runtime locations, including Finder-safe macOS paths."""
+    platform_name = sys.platform if platform_name is None else platform_name
+    frozen = bool(getattr(sys, "frozen", False)) if frozen is None else frozen
+    executable = Path(sys.executable) if executable is None else executable
+    raw_meipass = getattr(sys, "_MEIPASS", None) if meipass is None else meipass
+    meipass = Path(raw_meipass) if raw_meipass else None
+    repo_root = Path(__file__).resolve().parents[1] if repo_root is None else repo_root
+    names = [f"{tool_name}.exe", tool_name] if platform_name.startswith("win") else [tool_name, f"{tool_name}.exe"]
+
+    directories: list[Path] = []
+    if frozen:
+        directories.append(executable.resolve().parent)
+        if meipass is not None:
+            directories.append(meipass.resolve())
+    directories.append(repo_root)
+    if tool_name in {"ffmpeg", "ffprobe"}:
+        directories.append(repo_root / "vendor" / "ffmpeg" / "bin")
+    elif tool_name == "deno":
+        directories.append(repo_root / "vendor" / "deno")
+    if platform_name == "darwin":
+        # Finder-launched .apps do not reliably inherit a shell's Homebrew PATH.
+        directories.extend((Path("/opt/homebrew/bin"), Path("/usr/local/bin")))
+
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    override = os.environ.get(f"VODFORGE_{tool_name.upper()}")
+    if override:
+        override_path = Path(override).expanduser()
+        candidates.append(override_path)
+        seen.add(override_path)
+    for directory in directories:
+        for name in names:
+            candidate = directory / name
+            if candidate not in seen:
+                candidates.append(candidate)
+                seen.add(candidate)
+    return candidates
+
+
+def find_runtime_executable(tool_name: str) -> str | None:
+    for candidate in runtime_executable_candidates(tool_name):
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which(tool_name)
+
+
+def ytdlp_ffmpeg_location(ffmpeg: str) -> str:
+    """Point yt-dlp at an FFmpeg directory when the executable has a standard name."""
+    ffmpeg_path = Path(ffmpeg)
+    if ffmpeg_path.name.lower() in {"ffmpeg", "ffmpeg.exe"}:
+        return str(ffmpeg_path.parent)
+    return str(ffmpeg_path)
+
+
+def runtime_version_command(tool_name: str, executable: str) -> list[str]:
+    return [executable, "--version"] if tool_name == "deno" else [executable, "-version"]
+
+
+def probe_runtime_version(tool_name: str, executable: str) -> str:
+    """Execute a bundled runtime so smoke tests also catch missing dynamic libraries."""
+    startupinfo = None
+    creationflags = 0
+    if sys.platform.startswith("win"):
+        startupinfo = subprocess.STARTUPINFO()  # type: ignore[attr-defined]
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore[attr-defined]
+        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    result = subprocess.run(
+        runtime_version_command(tool_name, executable),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        startupinfo=startupinfo,
+        creationflags=creationflags,
+    )
+    return next((line.strip() for line in result.stdout.splitlines() if line.strip()), "version output unavailable")
 
 
 DIAGNOSTICS_LOG_PATH = diagnostics_dir() / "latest.log"
@@ -193,10 +303,13 @@ THEME = {
     "success": "#10b981",
     "border": "#34343a",
 }
-FONT_UI = ("Segoe UI", 10)
-FONT_UI_MEDIUM = ("Segoe UI", 10, "bold")
-FONT_TITLE = ("Segoe UI", 22, "bold")
-FONT_MONO = ("Cascadia Mono", 9)
+FONT_UI_FAMILY, FONT_MONO_FAMILY = platform_font_families()
+FONT_UI = (FONT_UI_FAMILY, 10)
+FONT_UI_SMALL = (FONT_UI_FAMILY, 9)
+FONT_UI_MEDIUM = (FONT_UI_FAMILY, 10, "bold")
+FONT_UI_SMALL_MEDIUM = (FONT_UI_FAMILY, 9, "bold")
+FONT_TITLE = (FONT_UI_FAMILY, 22, "bold")
+FONT_MONO = (FONT_MONO_FAMILY, 9)
 QUALITY_OPTIONS = {
     "Best available up to 4K": _format_selector(2160),
     "2160p / 4K": _format_selector(2160),
@@ -1818,7 +1931,7 @@ class ToolTip:
                 borderwidth=1,
                 padx=8,
                 pady=6,
-                font=("Segoe UI", 9),
+                font=FONT_UI_SMALL,
             )
             label.pack()
         except tk.TclError:
@@ -1923,11 +2036,11 @@ class DownloaderApp(tk.Tk):
         style.configure("Panel.TFrame", background=THEME["panel"])
         style.configure("Card.TFrame", background=THEME["surface"], relief="flat")
         style.configure("TLabel", background=THEME["bg"], foreground=THEME["text"], font=FONT_UI)
-        style.configure("Muted.TLabel", background=THEME["bg"], foreground=THEME["muted"], font=("Segoe UI", 9))
+        style.configure("Muted.TLabel", background=THEME["bg"], foreground=THEME["muted"], font=FONT_UI_SMALL)
         style.configure("Hero.TLabel", background=THEME["bg"], foreground=THEME["text"], font=FONT_TITLE)
-        style.configure("Accent.TLabel", background=THEME["bg"], foreground=THEME["accent"], font=("Segoe UI", 10, "bold"))
+        style.configure("Accent.TLabel", background=THEME["bg"], foreground=THEME["accent"], font=FONT_UI_MEDIUM)
         style.configure("TLabelframe", background=THEME["bg"], foreground=THEME["text"], bordercolor=THEME["border"], relief="solid")
-        style.configure("TLabelframe.Label", background=THEME["bg"], foreground=THEME["accent"], font=("Segoe UI", 10, "bold"))
+        style.configure("TLabelframe.Label", background=THEME["bg"], foreground=THEME["accent"], font=FONT_UI_MEDIUM)
         style.configure("TEntry", fieldbackground=THEME["surface"], foreground=THEME["text"], insertcolor=THEME["text"], bordercolor=THEME["border"], lightcolor=THEME["border"], darkcolor=THEME["border"], padding=7)
         style.configure("TCombobox", fieldbackground=THEME["surface"], foreground=THEME["text"], background=THEME["surface"], arrowcolor=THEME["accent"], bordercolor=THEME["border"], padding=6)
         style.map("TCombobox", fieldbackground=[("readonly", THEME["surface"]), ("active", THEME["surface_2"])], foreground=[("readonly", THEME["text"])])
@@ -1941,8 +2054,8 @@ class DownloaderApp(tk.Tk):
         style.configure("TNotebook", background=THEME["panel"], borderwidth=0, tabmargins=(8, 6, 8, 0))
         style.configure("TNotebook.Tab", background=THEME["surface"], foreground=THEME["muted"], padding=(18, 9), font=FONT_UI_MEDIUM, bordercolor=THEME["border"])
         style.map("TNotebook.Tab", background=[("selected", THEME["accent_dark"]), ("active", THEME["surface_2"])], foreground=[("selected", "#ffffff"), ("active", THEME["text"])], expand=[("selected", (0, 0, 0, 0))])
-        style.configure("Treeview", background=THEME["surface"], fieldbackground=THEME["surface"], foreground=THEME["text"], bordercolor=THEME["border"], rowheight=30, font=("Segoe UI", 10))
-        style.configure("Treeview.Heading", background=THEME["panel"], foreground=THEME["muted"], relief="flat", font=("Segoe UI", 9, "bold"))
+        style.configure("Treeview", background=THEME["surface"], fieldbackground=THEME["surface"], foreground=THEME["text"], bordercolor=THEME["border"], rowheight=30, font=FONT_UI)
+        style.configure("Treeview.Heading", background=THEME["panel"], foreground=THEME["muted"], relief="flat", font=FONT_UI_SMALL_MEDIUM)
         style.map("Treeview", background=[("selected", THEME["accent_dark"])], foreground=[("selected", "#ffffff")])
         self.option_add("*TCombobox*Listbox.background", THEME["surface"])
         self.option_add("*TCombobox*Listbox.foreground", THEME["text"])
@@ -2033,7 +2146,14 @@ class DownloaderApp(tk.Tk):
         ttk.Checkbutton(options, text="Embed metadata", variable=self.embed_metadata_var).grid(row=4, column=0, sticky="w", padx=10, pady=4)
         ttk.Checkbutton(options, text="Save compact JSON", variable=self.write_info_json_var).grid(row=4, column=1, sticky="w", padx=10, pady=4)
         ttk.Checkbutton(options, text="Single video only (ignore playlist)", variable=self.single_video_only_var).grid(row=5, column=0, columnspan=2, sticky="w", padx=10, pady=4)
-        ttk.Checkbutton(options, text="Use NVIDIA NVENC GPU encoding", variable=self.use_nvenc_var).grid(row=6, column=0, columnspan=2, sticky="w", padx=10, pady=4)
+        nvenc_label = "Use NVIDIA NVENC GPU encoding"
+        if sys.platform == "darwin":
+            nvenc_label += " (not available on macOS)"
+        nvenc_checkbox = ttk.Checkbutton(options, text=nvenc_label, variable=self.use_nvenc_var)
+        nvenc_checkbox.grid(row=6, column=0, columnspan=2, sticky="w", padx=10, pady=4)
+        if sys.platform == "darwin":
+            self.use_nvenc_var.set(False)
+            nvenc_checkbox.state(["disabled"])
         ttk.Checkbutton(options, text="Use YouTube cookies", variable=self.use_cookies_var).grid(row=7, column=0, columnspan=2, sticky="w", padx=10, pady=4)
 
         self.manual_settings_frame = ttk.LabelFrame(options, text="Manual Override Settings")
@@ -2180,7 +2300,7 @@ class DownloaderApp(tk.Tk):
         write_diagnostic(f"runtime path: ffmpeg={ffmpeg}")
         write_diagnostic(f"runtime path: deno={deno}")
         if not ffmpeg:
-            self._append_log("FFmpeg not found. Install FFmpeg on PATH or put ffmpeg.exe beside the packaged app.")
+            self._append_log("FFmpeg not found. Install FFmpeg or place its executable beside the packaged app.")
         else:
             self._append_log(f"FFmpeg found: {ffmpeg}")
         self._append_log(f"Diagnostics log: {DIAGNOSTICS_LOG_PATH}")
@@ -2319,8 +2439,7 @@ class DownloaderApp(tk.Tk):
             )
             ffmpeg = self._find_ffmpeg()
             if ffmpeg:
-                ffmpeg_path = Path(ffmpeg)
-                opts["ffmpeg_location"] = str(ffmpeg_path.parent if ffmpeg_path.name.lower() == "ffmpeg.exe" else ffmpeg_path)
+                opts["ffmpeg_location"] = ytdlp_ffmpeg_location(ffmpeg)
             deno = self._find_deno()
             if deno:
                 opts["js_runtimes"] = {"deno": {"path": deno}}
@@ -2700,8 +2819,7 @@ class DownloaderApp(tk.Tk):
                     apply_youtube_extractor_args(preflight_opts)
                     ffmpeg_for_preflight = self._find_ffmpeg()
                     if ffmpeg_for_preflight:
-                        ffmpeg_path = Path(ffmpeg_for_preflight)
-                        preflight_opts["ffmpeg_location"] = str(ffmpeg_path.parent if ffmpeg_path.name.lower() == "ffmpeg.exe" else ffmpeg_path)
+                        preflight_opts["ffmpeg_location"] = ytdlp_ffmpeg_location(ffmpeg_for_preflight)
                     deno = self._find_deno()
                     write_diagnostic(f"{label} preflight runtime path: ffmpeg={ffmpeg_for_preflight}")
                     write_diagnostic(f"{label} preflight runtime path: deno={deno}")
@@ -2920,8 +3038,7 @@ class DownloaderApp(tk.Tk):
         }
         ffmpeg = self._find_ffmpeg()
         if ffmpeg:
-            ffmpeg_path = Path(ffmpeg)
-            opts["ffmpeg_location"] = str(ffmpeg_path.parent if ffmpeg_path.name.lower() == "ffmpeg.exe" else ffmpeg_path)
+            opts["ffmpeg_location"] = ytdlp_ffmpeg_location(ffmpeg)
         deno = self._find_deno()
         if deno:
             opts["js_runtimes"] = {"deno": {"path": deno}}
@@ -2932,18 +3049,9 @@ class DownloaderApp(tk.Tk):
 
     @staticmethod
     def _find_ffmpeg() -> str | None:
-        candidates: list[Path] = []
-        if getattr(sys, "frozen", False):
-            candidates.append(Path(sys.executable).resolve().parent / "ffmpeg.exe")
-            candidates.append(Path(getattr(sys, "_MEIPASS", "")).resolve() / "ffmpeg.exe")
-        candidates.append(Path(__file__).resolve().parents[1] / "ffmpeg.exe")
-        candidates.append(Path(__file__).resolve().parents[1] / "vendor" / "ffmpeg" / "bin" / "ffmpeg.exe")
-        for candidate in candidates:
-            if candidate.exists():
-                return str(candidate)
-        path_ffmpeg = shutil.which("ffmpeg")
-        if path_ffmpeg:
-            return path_ffmpeg
+        runtime_ffmpeg = find_runtime_executable("ffmpeg")
+        if runtime_ffmpeg:
+            return runtime_ffmpeg
         try:
             import imageio_ffmpeg
 
@@ -2956,35 +3064,11 @@ class DownloaderApp(tk.Tk):
 
     @staticmethod
     def _find_ffprobe() -> str | None:
-        candidates: list[Path] = []
-        if getattr(sys, "frozen", False):
-            candidates.append(Path(sys.executable).resolve().parent / "ffprobe.exe")
-            candidates.append(Path(getattr(sys, "_MEIPASS", "")).resolve() / "ffprobe.exe")
-        candidates.append(Path(__file__).resolve().parents[1] / "ffprobe.exe")
-        candidates.append(Path(__file__).resolve().parents[1] / "vendor" / "ffmpeg" / "bin" / "ffprobe.exe")
-        for candidate in candidates:
-            if candidate.exists():
-                return str(candidate)
-        path_ffprobe = shutil.which("ffprobe")
-        if path_ffprobe:
-            return path_ffprobe
-        return None
+        return find_runtime_executable("ffprobe")
 
     @staticmethod
     def _find_deno() -> str | None:
-        candidates: list[Path] = []
-        if getattr(sys, "frozen", False):
-            candidates.append(Path(sys.executable).resolve().parent / "deno.exe")
-            candidates.append(Path(getattr(sys, "_MEIPASS", "")).resolve() / "deno.exe")
-        candidates.append(Path(__file__).resolve().parents[1] / "deno.exe")
-        candidates.append(Path(__file__).resolve().parents[1] / "vendor" / "deno" / "deno.exe")
-        for candidate in candidates:
-            if candidate.exists():
-                return str(candidate)
-        path_deno = shutil.which("deno")
-        if path_deno:
-            return path_deno
-        return None
+        return find_runtime_executable("deno")
 
     def _metadata_args(self, tags: list[str]) -> dict[str, list[str]]:
         if not tags:
@@ -3138,8 +3222,7 @@ def debug_preflight(url: str) -> int:
     }
     ffmpeg = DownloaderApp._find_ffmpeg()
     if ffmpeg:
-        ffmpeg_path = Path(ffmpeg)
-        opts["ffmpeg_location"] = str(ffmpeg_path.parent if ffmpeg_path.name.lower() == "ffmpeg.exe" else ffmpeg_path)
+        opts["ffmpeg_location"] = ytdlp_ffmpeg_location(ffmpeg)
     deno = DownloaderApp._find_deno()
     write_diagnostic(f"debug-preflight runtime path: ffmpeg={ffmpeg}")
     write_diagnostic(f"debug-preflight runtime path: deno={deno}")
@@ -3181,7 +3264,38 @@ def debug_preflight(url: str) -> int:
     return 0
 
 
+def runtime_smoke() -> int:
+    """Verify packaged dependencies without opening the GUI or fetching media."""
+    runtimes = {
+        "ffmpeg": DownloaderApp._find_ffmpeg(),
+        "ffprobe": DownloaderApp._find_ffprobe(),
+        "deno": DownloaderApp._find_deno(),
+    }
+    print(f"VODFORGE_RUNTIME_SMOKE platform={sys.platform} frozen={bool(getattr(sys, 'frozen', False))}")
+    failures: list[str] = []
+    for name, path in runtimes.items():
+        if not path:
+            print(f"{name}=missing")
+            failures.append(name)
+            continue
+        try:
+            version = probe_runtime_version(name, path)
+        except Exception as exc:
+            print(f"{name}={path} execution_failed={type(exc).__name__}: {exc}")
+            failures.append(name)
+        else:
+            print(f"{name}={path} version={version}")
+    print(f"diagnostics={DIAGNOSTICS_LOG_PATH}")
+    if failures:
+        print(f"VODFORGE_RUNTIME_SMOKE_FAILED runtimes={','.join(failures)}")
+        return 1
+    print("VODFORGE_RUNTIME_SMOKE_OK")
+    return 0
+
+
 def main() -> None:
+    if len(sys.argv) == 2 and sys.argv[1] == "--runtime-smoke":
+        raise SystemExit(runtime_smoke())
     if len(sys.argv) >= 3 and sys.argv[1] == "--debug-preflight":
         raise SystemExit(debug_preflight(" ".join(sys.argv[2:])))
     app = DownloaderApp()

--- a/yt_downloader/app.py
+++ b/yt_downloader/app.py
@@ -12,6 +12,7 @@ import unicodedata
 import urllib.parse
 import urllib.request
 import uuid
+import webbrowser
 from datetime import datetime
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -20,6 +21,25 @@ from typing import Any
 
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
+
+from .history import (
+    HistoryError,
+    application_data_dir,
+    history_file_path,
+    history_identity,
+    history_output_dir,
+    load_history,
+    save_history,
+    upsert_history,
+)
+from .updates import (
+    ReleaseInfo,
+    download_verified_update,
+    fetch_latest_release,
+    is_newer_release,
+    release_asset_for_platform,
+)
+from .version import __version__
 
 try:
     from PIL import Image, ImageTk
@@ -1985,6 +2005,7 @@ class DownloaderApp(tk.Tk):
 
         self.events: queue.Queue[tuple[str, Any]] = queue.Queue()
         self.worker: threading.Thread | None = None
+        self.update_worker: threading.Thread | None = None
         self.cancel_requested = False
         self.skip_video_requested = False
         self.skip_url_requested = False
@@ -2016,12 +2037,15 @@ class DownloaderApp(tk.Tk):
         self.thumbnail_image: Any | None = None
         self.last_thumbnail_url: str | None = None
         self.metadata_items: list[dict[str, Any]] = []
+        self.download_history: list[dict[str, Any]] = []
+        self.history_path = history_file_path()
         self.last_output_dirs: list[Path] = []
         self.video_output_dirs_by_id: dict[str, Path] = {}
         self._active_progress_context: tuple[int, int, float, float] | None = None
 
         self._apply_theme()
         self._build_ui()
+        self._load_download_history()
         self._check_runtime()
         self.after(100, self._pump_events)
 
@@ -2069,13 +2093,17 @@ class DownloaderApp(tk.Tk):
 
         hero = ttk.Frame(shell, style="Panel.TFrame")
         hero.pack(fill="x", padx=16, pady=(12, 4))
-        ttk.Label(hero, text="⬇ VODForge", style="Hero.TLabel").pack(anchor="w")
+        hero_header = ttk.Frame(hero, style="Panel.TFrame")
+        hero_header.pack(fill="x")
+        ttk.Label(hero_header, text="⬇ VODForge", style="Hero.TLabel").pack(side="left", anchor="w")
+        self.update_button = ttk.Button(hero_header, text="Check for updates", command=self._check_for_updates)
+        self.update_button.pack(side="right", anchor="e")
         ttk.Label(
             hero,
             text="VOD-ready MP4 downloads with H.264 CBR video, AAC audio, thumbnails, compact metadata, tags, and playlist packaging.",
             style="Muted.TLabel",
         ).pack(anchor="w", pady=(3, 0))
-        ttk.Label(hero, text="Midnight Violet build", style="Accent.TLabel").pack(anchor="w", pady=(6, 0))
+        ttk.Label(hero, text=f"Midnight Violet build · v{__version__}", style="Accent.TLabel").pack(anchor="w", pady=(6, 0))
 
         self.main_notebook = ttk.Notebook(shell)
         self.main_notebook.pack(fill="both", expand=True, padx=4, pady=(8, 4))
@@ -2231,6 +2259,7 @@ class DownloaderApp(tk.Tk):
         ttk.Button(meta_buttons, text="Copy Tags", command=self._copy_tags).pack(side="left", padx=5)
         ttk.Button(meta_buttons, text="Copy Description", command=self._copy_description).pack(side="left", padx=5)
         ttk.Button(meta_buttons, text="Copy Thumbnail URL", command=self._copy_thumbnail_url).pack(side="left", padx=5)
+        ttk.Button(meta_buttons, text="Open Saved Location", command=self._open_selected_saved_location).pack(side="left", padx=5)
         ttk.Button(meta_buttons, text="Back to Download", command=lambda: self.main_notebook.select(download_tab)).pack(side="right", padx=5)
 
         ttk.Label(metadata_tab, text="Playlist / Video Queue", style="Accent.TLabel").grid(row=1, column=0, sticky="w", padx=12, pady=(0, 5))
@@ -2240,7 +2269,7 @@ class DownloaderApp(tk.Tk):
         tree_wrap.rowconfigure(0, weight=1)
         self.video_tree = ttk.Treeview(
             tree_wrap,
-            columns=("index", "title", "duration", "creator", "id"),
+            columns=("index", "title", "duration", "creator", "id", "location"),
             show="headings",
             selectmode="browse",
             height=16,
@@ -2250,11 +2279,13 @@ class DownloaderApp(tk.Tk):
         self.video_tree.heading("duration", text="Length")
         self.video_tree.heading("creator", text="Creator")
         self.video_tree.heading("id", text="ID")
+        self.video_tree.heading("location", text="Saved Location")
         self.video_tree.column("index", width=56, minwidth=48, stretch=False, anchor="center")
         self.video_tree.column("title", width=620, minwidth=420, stretch=True, anchor="w")
         self.video_tree.column("duration", width=82, minwidth=70, stretch=False, anchor="center")
         self.video_tree.column("creator", width=170, minwidth=110, stretch=False, anchor="w")
         self.video_tree.column("id", width=120, minwidth=90, stretch=False, anchor="w")
+        self.video_tree.column("location", width=170, minwidth=120, stretch=False, anchor="w")
         y_scroll = ttk.Scrollbar(tree_wrap, orient="vertical", command=self.video_tree.yview)
         x_scroll = ttk.Scrollbar(tree_wrap, orient="horizontal", command=self.video_tree.xview)
         self.video_tree.configure(yscrollcommand=y_scroll.set, xscrollcommand=x_scroll.set)
@@ -2305,6 +2336,111 @@ class DownloaderApp(tk.Tk):
             self._append_log(f"FFmpeg found: {ffmpeg}")
         self._append_log(f"Diagnostics log: {DIAGNOSTICS_LOG_PATH}")
 
+    def _check_for_updates(self) -> None:
+        if self.update_worker and self.update_worker.is_alive():
+            return
+        self.update_button.config(state="disabled")
+        self.status_var.set("Checking GitHub Releases for a VODForge update…")
+        self.update_worker = threading.Thread(target=self._update_check_worker, daemon=True)
+        self.update_worker.start()
+
+    def _update_check_worker(self) -> None:
+        try:
+            self.events.put(("update_check_result", fetch_latest_release()))
+        except Exception as exc:
+            self.events.put(("update_check_error", str(exc)))
+
+    def _show_update_result(self, release: ReleaseInfo) -> None:
+        self.update_button.config(state="normal")
+        if not is_newer_release(__version__, release.version):
+            self.status_var.set(f"VODForge v{__version__} is up to date.")
+            messagebox.showinfo(APP_NAME, f"You are using the latest VODForge release (v{__version__}).")
+            return
+        self.status_var.set(f"VODForge {release.tag_name} is available.")
+        if sys.platform.startswith("win") and release_asset_for_platform(release) is not None:
+            if messagebox.askyesno(
+                APP_NAME,
+                f"VODForge {release.tag_name} is available.\n\nDownload the release artifact, verify its SHA-256 checksum, and start the updater?",
+            ):
+                self._start_update_download(release)
+            return
+        if messagebox.askyesno(
+            APP_NAME,
+            f"VODForge {release.tag_name} is available.\n\nOpen the verified GitHub Release page to download it?",
+        ):
+            webbrowser.open(release.html_url)
+
+    def _start_update_download(self, release: ReleaseInfo) -> None:
+        self.update_button.config(state="disabled")
+        self.status_var.set(f"Downloading and verifying VODForge {release.tag_name}…")
+        self.update_worker = threading.Thread(target=self._update_download_worker, args=(release,), daemon=True)
+        self.update_worker.start()
+
+    def _update_download_worker(self, release: ReleaseInfo) -> None:
+        try:
+            destination = application_data_dir() / "updates" / release.tag_name
+            path = download_verified_update(release, destination)
+            self.events.put(("update_ready", path))
+        except Exception as exc:
+            self.events.put(("update_check_error", str(exc)))
+
+    def _install_downloaded_update(self, path: Path) -> None:
+        self.update_button.config(state="normal")
+        if not sys.platform.startswith("win") or path.suffix.lower() != ".exe":
+            self.status_var.set(f"Verified update downloaded: {path.name}")
+            self._open_path(path.parent)
+            return
+        try:
+            subprocess.Popen(
+                [str(path), "/SP-", "/SILENT", "/CLOSEAPPLICATIONS", "/RESTARTAPPLICATIONS"],
+                close_fds=True,
+            )
+        except OSError as exc:
+            messagebox.showerror(APP_NAME, f"The verified updater could not be started:\n\n{exc}")
+            return
+        self.status_var.set("Verified updater started. VODForge will close and reopen when installation completes.")
+
+    def _load_download_history(self) -> None:
+        try:
+            self.download_history = load_history(self.history_path)
+        except HistoryError as exc:
+            self.download_history = []
+            self._append_log(f"WARNING: {exc}")
+            self.status_var.set("Download history could not be loaded; the existing history file was left untouched.")
+            return
+        self.metadata_items = [dict(item) for item in self.download_history]
+        self._rebuild_output_dir_index()
+        self._render_metadata_tree()
+        if self.download_history:
+            self.status_var.set(f"Loaded {len(self.download_history)} downloaded video(s) from history.")
+            self._append_log(f"Loaded download history: {self.history_path}")
+
+    def _record_download_history(self, info: dict[str, Any], output_dir: Path) -> None:
+        try:
+            self.download_history = upsert_history(self.download_history, info, output_dir)
+            save_history(self.history_path, self.download_history)
+        except HistoryError as exc:
+            self._append_log(f"WARNING: {exc}")
+            self.status_var.set("The video finished, but VODForge could not save it to local history.")
+            return
+
+        saved_record = self.download_history[0]
+        saved_id = str(saved_record.get("id") or "")
+        merged = dict(saved_record)
+        retained: list[dict[str, Any]] = []
+        for item in self.metadata_items:
+            if history_identity(item) == history_identity(saved_record):
+                merged = {**item, **saved_record}
+                continue
+            if saved_id and str(item.get("id") or "") == saved_id and history_output_dir(item) is None:
+                merged = {**item, **saved_record}
+                continue
+            retained.append(item)
+        self.metadata_items = [merged, *retained]
+        self._rebuild_output_dir_index()
+        self._render_metadata_tree(selected_index=0)
+        self._append_log(f"Saved download history entry: {output_dir}")
+
     def _manual_help_icon(self, row: int, text: str) -> None:
         icon = ttk.Label(self.manual_settings_frame, text="?", style="Accent.TLabel", cursor="question_arrow")
         icon.grid(row=row, column=2, sticky="w", padx=(2, 8), pady=6)
@@ -2345,7 +2481,26 @@ class DownloaderApp(tk.Tk):
             self.output_var.set(folder)
 
     def _open_folder(self) -> None:
-        path = self._folder_to_open()
+        saved = self._selected_saved_folder()
+        if saved is not None:
+            self._open_existing_saved_folder(saved)
+            return
+        self._open_path(self._folder_to_open())
+
+    def _open_selected_saved_location(self) -> None:
+        saved = self._selected_saved_folder()
+        if saved is None:
+            messagebox.showinfo(APP_NAME, "This preview does not have a saved download location yet.")
+            return
+        self._open_existing_saved_folder(saved)
+
+    def _open_existing_saved_folder(self, path: Path) -> None:
+        if not path.is_dir():
+            messagebox.showwarning(
+                APP_NAME,
+                f"The saved folder is no longer available:\n\n{path}\n\nThe history entry was kept so you can still review its metadata.",
+            )
+            return
         self._open_path(path)
 
     def _open_log_folder(self) -> None:
@@ -2363,18 +2518,22 @@ class DownloaderApp(tk.Tk):
             subprocess.Popen(["xdg-open", str(path)])
 
     def _folder_to_open(self) -> Path:
+        saved = self._selected_saved_folder()
+        if saved is not None:
+            return saved
+        if self.last_output_dirs:
+            return self.last_output_dirs[-1]
+        return Path(self.output_var.get()).expanduser()
+
+    def _selected_saved_folder(self) -> Path | None:
         selection = getattr(self, "video_tree", None).selection() if hasattr(self, "video_tree") else ()
         if selection:
             try:
                 info = self.metadata_items[int(selection[0])]
-                video_id = str(info.get("id") or "")
-                if video_id and video_id in self.video_output_dirs_by_id:
-                    return self.video_output_dirs_by_id[video_id]
+                return history_output_dir(info)
             except (IndexError, TypeError, ValueError):
                 pass
-        if self.last_output_dirs:
-            return self.last_output_dirs[-1]
-        return Path(self.output_var.get()).expanduser()
+        return None
 
     def _load_url_list_file(self) -> None:
         path = filedialog.askopenfilename(
@@ -2474,28 +2633,46 @@ class DownloaderApp(tk.Tk):
 
     def _display_metadata(self, info: dict[str, Any]) -> None:
         incoming_items = iter_video_infos(info)
-        if not (isinstance(info.get("entries"), list)) and incoming_items and self.metadata_items:
-            existing_by_id = {str(item.get("id") or ""): item for item in self.metadata_items}
-            for incoming in incoming_items:
-                video_id = str(incoming.get("id") or "")
-                if video_id and video_id in existing_by_id:
-                    existing_by_id[video_id].update(incoming)
-                else:
-                    self.metadata_items.append(incoming)
-        else:
-            self.metadata_items = incoming_items
+        new_items: list[dict[str, Any]] = []
+        for incoming in incoming_items:
+            video_id = str(incoming.get("id") or "")
+            matching = next(
+                (item for item in [*new_items, *self.metadata_items] if video_id and str(item.get("id") or "") == video_id),
+                None,
+            )
+            if matching is not None:
+                matching.update(incoming)
+            else:
+                new_items.append(incoming)
+        if new_items:
+            self.metadata_items = [*new_items, *self.metadata_items]
+        self._rebuild_output_dir_index()
+        self._render_metadata_tree()
+        self.status_var.set(f"Showing metadata for {len(incoming_items)} fetched video(s); saved history remains available.")
+
+    def _rebuild_output_dir_index(self) -> None:
+        self.video_output_dirs_by_id = {}
+        for item in self.metadata_items:
+            video_id = str(item.get("id") or "")
+            output_dir = history_output_dir(item)
+            if video_id and output_dir is not None:
+                self.video_output_dirs_by_id.setdefault(video_id, output_dir)
+
+    def _render_metadata_tree(self, *, selected_index: int | None = None) -> None:
         selected_iid = self.video_tree.selection()[0] if self.video_tree.selection() else None
         for item in self.video_tree.get_children():
             self.video_tree.delete(item)
         for idx, item in enumerate(self.metadata_items, start=1):
-            values = video_list_row_values(item, fallback_index=idx)
+            output_dir = history_output_dir(item)
+            location = output_dir.name if output_dir is not None else "Preview only"
+            values = (*video_list_row_values(item, fallback_index=idx), location)
             self.video_tree.insert("", "end", iid=str(idx - 1), values=values)
         if self.metadata_items:
-            target = selected_iid if selected_iid in self.video_tree.get_children() else self.video_tree.get_children()[0]
+            preferred = str(selected_index) if selected_index is not None else selected_iid
+            target = preferred if preferred in self.video_tree.get_children() else self.video_tree.get_children()[0]
             self.video_tree.selection_set(target)
             self.video_tree.focus(target)
             self._display_selected_metadata(int(target))
-        self.status_var.set(f"Fetched metadata for {len(self.metadata_items)} video(s).")
 
     def _on_video_selected(self, _event: Any = None) -> None:
         selection = self.video_tree.selection()
@@ -2519,7 +2696,11 @@ class DownloaderApp(tk.Tk):
         info = self.metadata_items[index]
         title = str(info.get("title") or info.get("id") or "selected video")
         creator = str(info.get("uploader") or info.get("channel") or "Unknown creator")
-        self.selected_title_var.set(f"{title}\n{creator} • {format_duration(info.get('duration'))} • {info.get('id') or 'no id'}")
+        saved = history_output_dir(info)
+        location_text = f"Saved in {saved}" if saved is not None else "Not downloaded in this history"
+        self.selected_title_var.set(
+            f"{title}\n{creator} • {format_duration(info.get('duration'))} • {info.get('id') or 'no id'}\n{location_text}"
+        )
         tags_text = build_tags_display_text(info)
         description = build_description_display_text(info)
         self._set_text(self.pulled_tags_text, tags_text or "No tags found for this video.")
@@ -2529,11 +2710,27 @@ class DownloaderApp(tk.Tk):
         self._set_text(self.output_summary_text, output_summary, disabled=True)
         thumb = best_thumbnail(info)
         self.last_thumbnail_url = str((thumb or {}).get("url") or "") or None
-        if self.last_thumbnail_url:
+        local_thumbnail = saved / "thumbnail.jpeg" if saved is not None else None
+        if local_thumbnail is not None and local_thumbnail.is_file():
+            self._load_thumbnail_file(local_thumbnail)
+        elif self.last_thumbnail_url:
             self._load_thumbnail_preview(self.last_thumbnail_url)
         else:
             self.thumbnail_label.config(image="", text="No thumbnail loaded")
         self.status_var.set(f"Showing metadata for: {info.get('title') or info.get('id') or 'selected video'}")
+
+    def _load_thumbnail_file(self, path: Path) -> None:
+        if Image is None or ImageTk is None:
+            self.thumbnail_label.config(text=f"Saved thumbnail:\n{path}")
+            return
+        try:
+            with Image.open(path) as source:
+                image = source.copy()
+            image.thumbnail((260, 150))
+            self.thumbnail_image = ImageTk.PhotoImage(image)
+            self.thumbnail_label.config(image=self.thumbnail_image, text="")
+        except Exception as exc:
+            self.thumbnail_label.config(text=f"Saved thumbnail preview failed:\n{exc}\n\n{path}")
 
     def _load_thumbnail_preview(self, url: str) -> None:
         if Image is None or ImageTk is None:
@@ -2946,6 +3143,13 @@ class DownloaderApp(tk.Tk):
                         )
                         current_video_info = info
                         self.events.put(("metadata", info))
+                        if primary_output is not None:
+                            self.events.put(
+                                (
+                                    "history_record",
+                                    {"info": info, "output_dir": str(primary_output.parent)},
+                                )
+                            )
                         if job.write_info_json:
                             metadata_path = write_compact_video_metadata(resolved_video_output_dir(job.output_dir, info), info, job.tags)
                             self.events.put(("log", f"{label}: saved compact video metadata {metadata_path}"))
@@ -3145,18 +3349,27 @@ class DownloaderApp(tk.Tk):
                 elif kind == "metadata":
                     if isinstance(payload, dict):
                         self._display_metadata(payload)
+                elif kind == "history_record":
+                    if isinstance(payload, dict) and isinstance(payload.get("info"), dict):
+                        output_dir = str(payload.get("output_dir") or "").strip()
+                        if output_dir:
+                            self._record_download_history(payload["info"], Path(output_dir))
                 elif kind == "metadata_fetch_done":
                     if hasattr(self, "preview_metadata_button"):
                         self.preview_metadata_button.config(state="normal")
                 elif kind == "download_folders":
                     if isinstance(payload, list):
                         self.last_output_dirs = [Path(path) for path in payload]
-                        self.video_output_dirs_by_id = {}
-                        for info in self.metadata_items:
-                            video_id = str(info.get("id") or "")
-                            folder = video_output_dir(Path(self.output_var.get()).expanduser(), info)
-                            if video_id and folder in self.last_output_dirs:
-                                self.video_output_dirs_by_id[video_id] = folder
+                elif kind == "update_check_result":
+                    if isinstance(payload, ReleaseInfo):
+                        self._show_update_result(payload)
+                elif kind == "update_ready":
+                    if isinstance(payload, Path):
+                        self._install_downloaded_update(payload)
+                elif kind == "update_check_error":
+                    self.update_button.config(state="normal")
+                    self.status_var.set("Could not check for updates.")
+                    messagebox.showinfo(APP_NAME, str(payload))
                 elif kind == "done":
                     self.progress_var.set(100)
                     self.status_var.set(str(payload))
@@ -3271,7 +3484,10 @@ def runtime_smoke() -> int:
         "ffprobe": DownloaderApp._find_ffprobe(),
         "deno": DownloaderApp._find_deno(),
     }
-    print(f"VODFORGE_RUNTIME_SMOKE platform={sys.platform} frozen={bool(getattr(sys, 'frozen', False))}")
+    print(
+        f"VODFORGE_RUNTIME_SMOKE version={__version__} "
+        f"platform={sys.platform} frozen={bool(getattr(sys, 'frozen', False))}"
+    )
     failures: list[str] = []
     for name, path in runtimes.items():
         if not path:

--- a/yt_downloader/history.py
+++ b/yt_downloader/history.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+APP_NAME = "VODForge"
+HISTORY_SCHEMA_VERSION = 1
+MAX_HISTORY_ITEMS = 5000
+MAX_DESCRIPTION_CHARS = 20_000
+MAX_HISTORY_FILE_BYTES = 128 * 1024 * 1024
+
+HISTORY_METADATA_KEYS = (
+    "id",
+    "title",
+    "webpage_url",
+    "original_url",
+    "description",
+    "duration",
+    "uploader",
+    "channel",
+    "tags",
+    "extra_tags",
+    "categories",
+    "thumbnail",
+    "best_thumbnail",
+    "playlist_title",
+    "playlist_id",
+    "playlist_index",
+    "vodforge_encoding_summary",
+)
+
+
+class HistoryError(RuntimeError):
+    """Raised when the local history ledger cannot be read or written safely."""
+
+
+def application_data_dir(
+    *,
+    platform_name: str | None = None,
+    home: Path | None = None,
+    local_app_data: str | None = None,
+    xdg_data_home: str | None = None,
+) -> Path:
+    """Return the conventional per-user application-data directory."""
+    platform_name = sys.platform if platform_name is None else platform_name
+    home = Path.home() if home is None else home
+    if platform_name.startswith("win"):
+        base = local_app_data if local_app_data is not None else os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / APP_NAME
+        return home / "AppData" / "Local" / APP_NAME
+    if platform_name == "darwin":
+        return home / "Library" / "Application Support" / APP_NAME
+    base = xdg_data_home if xdg_data_home is not None else os.environ.get("XDG_DATA_HOME")
+    return (Path(base).expanduser() if base else home / ".local" / "share") / APP_NAME.lower()
+
+
+def history_file_path(**kwargs: Any) -> Path:
+    return application_data_dir(**kwargs) / "download-history.json"
+
+
+def _clean_string_list(value: Any, *, limit: int = 500) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        result.append(text)
+        seen.add(text)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _json_safe(value: Any) -> Any:
+    try:
+        encoded = json.dumps(value)
+    except (TypeError, ValueError):
+        return None
+    if len(encoded.encode("utf-8")) > 200_000:
+        return None
+    return value
+
+
+def history_output_dir(record: dict[str, Any]) -> Path | None:
+    value = str(record.get("vodforge_output_dir") or "").strip()
+    return Path(value).expanduser() if value else None
+
+
+def history_identity(record: dict[str, Any]) -> tuple[str, str]:
+    video_id = str(record.get("id") or "").strip()
+    output_dir = history_output_dir(record)
+    normalized_dir = os.path.normcase(os.path.abspath(str(output_dir))) if output_dir else ""
+    if video_id:
+        return video_id, normalized_dir
+    return str(record.get("title") or "").strip(), normalized_dir
+
+
+def sanitize_history_record(
+    info: dict[str, Any],
+    output_dir: Path | str,
+    *,
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    """Keep only metadata needed by the browser and the exact saved location."""
+    record: dict[str, Any] = {}
+    for key in HISTORY_METADATA_KEYS:
+        value = info.get(key)
+        if key in {"tags", "extra_tags", "categories"}:
+            value = _clean_string_list(value)
+        elif key == "description":
+            value = str(value or "")[:MAX_DESCRIPTION_CHARS]
+        else:
+            value = _json_safe(value)
+        if value not in (None, "", [], {}):
+            record[key] = value
+
+    path = Path(output_dir).expanduser()
+    try:
+        path = path.resolve(strict=False)
+    except OSError:
+        path = Path(os.path.abspath(str(path)))
+    record["vodforge_output_dir"] = str(path)
+    record["vodforge_recorded_at"] = recorded_at or datetime.now(timezone.utc).isoformat()
+    return record
+
+
+def upsert_history(
+    existing: list[dict[str, Any]],
+    info: dict[str, Any],
+    output_dir: Path | str,
+    *,
+    recorded_at: str | None = None,
+) -> list[dict[str, Any]]:
+    record = sanitize_history_record(info, output_dir, recorded_at=recorded_at)
+    identity = history_identity(record)
+    remaining = [item for item in existing if history_identity(item) != identity]
+    return [record, *remaining][:MAX_HISTORY_ITEMS]
+
+
+def save_history(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": HISTORY_SCHEMA_VERSION,
+        "items": records[:MAX_HISTORY_ITEMS],
+    }
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        if os.name != "nt":
+            temporary.chmod(0o600)
+        temporary.replace(path)
+    except (OSError, TypeError, ValueError) as exc:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise HistoryError(f"VODForge could not save download history: {exc}") from exc
+
+
+def load_history(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        if path.stat().st_size > MAX_HISTORY_FILE_BYTES:
+            raise HistoryError("VODForge found an unexpectedly large download-history file.")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HistoryError(f"VODForge could not read download history: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != HISTORY_SCHEMA_VERSION:
+        raise HistoryError("VODForge found an unsupported download-history file.")
+    raw_items = payload.get("items")
+    if not isinstance(raw_items, list):
+        raise HistoryError("VODForge found an invalid download-history file.")
+
+    records: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        output_dir = history_output_dir(item)
+        if output_dir is None:
+            continue
+        record = sanitize_history_record(
+            item,
+            output_dir,
+            recorded_at=str(item.get("vodforge_recorded_at") or "").strip() or None,
+        )
+        identity = history_identity(record)
+        if identity in seen:
+            continue
+        records.append(record)
+        seen.add(identity)
+        if len(records) >= MAX_HISTORY_ITEMS:
+            break
+    return records

--- a/yt_downloader/updates.py
+++ b/yt_downloader/updates.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import hashlib
+import os
+import platform
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+GITHUB_REPOSITORY = "SnowfallHD/vodforge"
+LATEST_RELEASE_API = f"https://api.github.com/repos/{GITHUB_REPOSITORY}/releases/latest"
+RELEASES_PAGE = f"https://github.com/{GITHUB_REPOSITORY}/releases/latest"
+MAX_RELEASE_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_UPDATE_ASSET_BYTES = 4 * 1024 * 1024 * 1024
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$")
+SHA256_RE = re.compile(r"^([0-9a-fA-F]{64})\s+[ *](.+)$")
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    name: str
+    download_url: str
+    size: int
+
+
+@dataclass(frozen=True)
+class ReleaseInfo:
+    version: str
+    tag_name: str
+    name: str
+    html_url: str
+    notes: str
+    assets: tuple[ReleaseAsset, ...]
+
+
+def semantic_version_key(version: str) -> tuple[int, int, int, int, str]:
+    match = SEMVER_RE.fullmatch(str(version).strip())
+    if not match:
+        raise ValueError(f"Unsupported release version: {version!r}")
+    major, minor, patch = (int(match.group(index)) for index in range(1, 4))
+    prerelease = match.group(4) or ""
+    return major, minor, patch, 1 if not prerelease else 0, prerelease
+
+
+def is_newer_release(current_version: str, release_version: str) -> bool:
+    return semantic_version_key(release_version) > semantic_version_key(current_version)
+
+
+def _trusted_github_page(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname not in {"github.com", "www.github.com"}:
+        raise ValueError("GitHub returned an invalid release page URL.")
+    return url
+
+
+def _trusted_github_download(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname not in {"github.com", "www.github.com"}:
+        raise ValueError("GitHub returned an invalid release download URL.")
+    return url
+
+
+def parse_release_payload(payload: dict[str, Any]) -> ReleaseInfo:
+    if payload.get("draft") or payload.get("prerelease"):
+        raise ValueError("GitHub's latest release is not a public stable release.")
+    tag_name = str(payload.get("tag_name") or "").strip()
+    version_match = SEMVER_RE.fullmatch(tag_name)
+    if not version_match:
+        raise ValueError("GitHub's latest release does not use a semantic version tag.")
+    if version_match.group(4):
+        raise ValueError("GitHub's latest release is not a stable semantic version.")
+    version = ".".join(version_match.group(index) for index in range(1, 4))
+    assets: list[ReleaseAsset] = []
+    for raw_asset in payload.get("assets") or []:
+        if not isinstance(raw_asset, dict):
+            continue
+        name = str(raw_asset.get("name") or "").strip()
+        download_url = str(raw_asset.get("browser_download_url") or "").strip()
+        try:
+            size = int(raw_asset.get("size") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        if not name or not download_url:
+            continue
+        assets.append(ReleaseAsset(name=name, download_url=_trusted_github_download(download_url), size=size))
+    return ReleaseInfo(
+        version=version,
+        tag_name=tag_name,
+        name=str(payload.get("name") or tag_name).strip(),
+        html_url=_trusted_github_page(str(payload.get("html_url") or "").strip()),
+        notes=str(payload.get("body") or "").strip(),
+        assets=tuple(assets),
+    )
+
+
+def fetch_latest_release(*, timeout: float = 15) -> ReleaseInfo:
+    request = urllib.request.Request(
+        LATEST_RELEASE_API,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"VODForge update checker ({GITHUB_REPOSITORY})",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read(MAX_RELEASE_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise RuntimeError("No packaged VODForge release is available yet.") from exc
+        raise RuntimeError(f"GitHub could not check for updates (HTTP {exc.code}).") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError("VODForge could not reach GitHub to check for updates.") from exc
+    if len(raw) > MAX_RELEASE_RESPONSE_BYTES:
+        raise RuntimeError("GitHub returned an unexpectedly large release response.")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("GitHub returned an unreadable release response.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub returned an invalid release response.")
+    return parse_release_payload(payload)
+
+
+def release_asset_for_platform(
+    release: ReleaseInfo,
+    *,
+    platform_name: str | None = None,
+    machine: str | None = None,
+) -> ReleaseAsset | None:
+    platform_name = sys.platform if platform_name is None else platform_name
+    machine = platform.machine().lower() if machine is None else machine.lower()
+    if platform_name.startswith("win"):
+        expected = f"VODForge-Windows-Setup-v{release.version}.exe"
+    elif platform_name == "darwin":
+        architecture = "arm64" if machine in {"arm64", "aarch64"} else "x64"
+        expected = f"VODForge-macOS-{architecture}-v{release.version}.zip"
+    else:
+        return None
+    return next((asset for asset in release.assets if asset.name == expected), None)
+
+
+def parse_sha256sums(text: str) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        match = SHA256_RE.fullmatch(raw_line.strip())
+        if match:
+            checksums[match.group(2)] = match.group(1).lower()
+    return checksums
+
+
+def _fetch_small_text(url: str, *, timeout: float) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": f"VODForge updater ({GITHUB_REPOSITORY})"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read(MAX_RELEASE_RESPONSE_BYTES + 1)
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        raise RuntimeError("VODForge could not download the release checksums.") from exc
+    if len(raw) > MAX_RELEASE_RESPONSE_BYTES:
+        raise RuntimeError("The release checksum file is unexpectedly large.")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("The release checksum file is unreadable.") from exc
+
+
+def download_verified_update(
+    release: ReleaseInfo,
+    destination_dir: Path,
+    *,
+    platform_name: str | None = None,
+    machine: str | None = None,
+    timeout: float = 60,
+) -> Path:
+    asset = release_asset_for_platform(release, platform_name=platform_name, machine=machine)
+    if asset is None:
+        raise RuntimeError("This release does not include an update for this computer.")
+    if asset.size <= 0 or asset.size > MAX_UPDATE_ASSET_BYTES:
+        raise RuntimeError("The release update has an invalid file size.")
+    checksum_asset = next((item for item in release.assets if item.name == "SHA256SUMS.txt"), None)
+    if checksum_asset is None:
+        raise RuntimeError("This release is missing its SHA-256 checksum manifest.")
+    expected_hash = parse_sha256sums(_fetch_small_text(checksum_asset.download_url, timeout=timeout)).get(asset.name)
+    if not expected_hash:
+        raise RuntimeError("This release is missing the update file's SHA-256 checksum.")
+
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination = destination_dir / asset.name
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    digest = hashlib.sha256()
+    downloaded = 0
+    request = urllib.request.Request(asset.download_url, headers={"User-Agent": f"VODForge updater ({GITHUB_REPOSITORY})"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response, temporary.open("wb") as output:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                downloaded += len(chunk)
+                if downloaded > asset.size or downloaded > MAX_UPDATE_ASSET_BYTES:
+                    raise RuntimeError("The release update exceeded its declared file size.")
+                digest.update(chunk)
+                output.write(chunk)
+        if downloaded != asset.size:
+            raise RuntimeError("The release update did not match its declared file size.")
+        if digest.hexdigest().lower() != expected_hash:
+            raise RuntimeError("The release update failed SHA-256 verification and was not opened.")
+        temporary.replace(destination)
+        if os.name != "nt":
+            destination.chmod(0o700)
+        return destination
+    except (OSError, urllib.error.HTTPError, urllib.error.URLError) as exc:
+        raise RuntimeError("VODForge could not download the release update.") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/yt_downloader/version.py
+++ b/yt_downloader/version.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_VERSION = "0.1.0-dev"
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+
+
+def bundled_version_file() -> Path | None:
+    raw_meipass = getattr(sys, "_MEIPASS", None)
+    if not raw_meipass:
+        return None
+    return Path(raw_meipass) / "VODFORGE_VERSION"
+
+
+def read_app_version(path: Path | None = None) -> str:
+    path = bundled_version_file() if path is None else path
+    if path is None:
+        return DEFAULT_VERSION
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return DEFAULT_VERSION
+    return value if VERSION_RE.fullmatch(value) else DEFAULT_VERSION
+
+
+__version__ = read_app_version()


### PR DESCRIPTION
## Summary
- add macOS application support and packaged runtime smoke coverage
- persist privacy-allowlisted completed-download history
- add stable GitHub Release update checks and Windows installer packaging
- sign Windows application and installer through repository-scoped Azure OIDC
- add fail-closed Developer ID signing, notarization, stapling, and release finalization for both macOS architectures

## Verification
- 102 tests passed locally
- source compile, workflow YAML parse, shell syntax, PowerShell parse, and git diff checks passed
- arm64 0.1.0 build passed bundled FFmpeg/ffprobe/Deno runtime smoke
- arm64 app was Developer ID signed, Apple notarization accepted, stapled, and Gatekeeper accepted

No media was downloaded.