### PR TITLE
Fix cross-platform release runner setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies
-        run: brew install python@3.13 python-tk@3.13 ffmpeg deno
+        run: |
+          if ! brew install python@3.13 python-tk@3.13 ffmpeg deno; then
+            for formula in python@3.13 python-tk@3.13 ffmpeg deno; do
+              brew list --versions "$formula" >/dev/null
+            done
+          fi
+          echo "$(brew --prefix python@3.13)/bin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix ffmpeg)/bin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix deno)/bin" >> "$GITHUB_PATH"
       - name: Build unsigned macOS review application
         env:
           VODFORGE_UNSIGNED_REVIEW: "1"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -26,6 +26,14 @@ def test_release_workflow_keeps_macos_artifacts_explicitly_review_only():
     assert "Do not publish the draft until both macOS architectures" in workflow
 
 
+def test_macos_dependency_install_recovers_only_when_every_formula_is_present():
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    assert "if ! brew install python@3.13 python-tk@3.13 ffmpeg deno; then" in workflow
+    assert 'brew list --versions "$formula"' in workflow
+    assert 'brew --prefix python@3.13' in workflow
+
+
 def test_macos_release_script_requires_accepted_notarization_and_stapling():
     script = (ROOT / "sign_and_notarize_macos.sh").read_text()
 


### PR DESCRIPTION
## Summary
- recover from the known Intel runner Homebrew link collision only when every required formula is verifiably installed
- put the selected Homebrew Python, FFmpeg, and Deno paths first for the subsequent build

The Azure OIDC credential was separately narrowed to GitHub immutable repository IDs after the first live assertion exposed the current subject format.

## Verification
- 103 tests pass locally
- release workflow YAML and diff checks pass
- first release run remained fail-closed and created no draft release