### PR TITLE
Add automatic signed application updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ VODForge analyzes the available source streams, chooses a practical video/audio 
 - Includes browser-cookie and `cookies.txt` options for videos you are authorized to access.
 - Shows progress, speed, ETA, diagnostics, and per-item batch failures.
 - Keeps a private, local Metadata Browser history of completed downloads and their saved folders across app restarts.
-- Checks versioned, stable GitHub Releases for updates; it never installs code directly from the repository's `main` branch.
+- Checks versioned, stable GitHub Releases automatically after startup and every six hours; it never installs code directly from the repository's `main` branch.
 
 ## Install a packaged release
 
@@ -147,7 +147,7 @@ The manually dispatched **Build Release Draft** GitHub Actions workflow builds:
 
 It creates a GitHub **draft** release only. Windows application and installer signing uses Azure Artifact Signing through a repository-specific OIDC identity; no long-lived Azure password is stored in GitHub. The macOS jobs produce explicit unsigned review archives for both architectures. On the signing Mac, `./finalize_macos_release.sh <version>` downloads those review builds, Developer ID signs them, submits each to Apple notarization, staples and Gatekeeper-checks them, runs the packaged-runtime smoke tests, uploads the final archives, removes the unsigned review assets, and regenerates `SHA256SUMS.txt`.
 
-After the draft assets and checksums are reviewed, publishing the draft makes it the update source. The app's update check reads only the latest public, stable GitHub Release. On Windows it downloads the matching signed installer, verifies its exact size and SHA-256 checksum from the same release, and starts the updater. macOS opens the verified release page until an in-app signed replacement path is implemented.
+After the draft assets and checksums are reviewed, publishing the draft makes it the update source. Packaged apps check only the latest public, stable GitHub Release after startup and every six hours, while retaining the manual **Check for updates** control. When a newer version is approved by the user, Windows downloads the matching installer, verifies its exact size, SHA-256 checksum, Kryden Ventures Authenticode publisher, and trusted timestamp, then starts the silent installer. macOS downloads the matching architecture, verifies its size and checksum, exact VODForge bundle and Apple team identities, strict Developer ID signature, stapled notarization ticket, and Gatekeeper acceptance, then uses a detached rollback-capable swapper to replace and relaunch the app.
 
 ## Development
 

--- a/tests/test_update_ui.py
+++ b/tests/test_update_ui.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yt_downloader.app as app_module
+from yt_downloader.app import DownloaderApp
+from yt_downloader.updates import MacUpdatePlan, ReleaseAsset, ReleaseInfo
+
+
+class FakeButton:
+    def __init__(self) -> None:
+        self.values = {}
+
+    def config(self, **kwargs) -> None:
+        self.values.update(kwargs)
+
+
+class FakeVar:
+    def __init__(self, value: str = "") -> None:
+        self.value = value
+
+    def set(self, value: str) -> None:
+        self.value = value
+
+
+def _release(version: str) -> ReleaseInfo:
+    tag = f"v{version}"
+    return ReleaseInfo(
+        version=version,
+        tag_name=tag,
+        name=f"VODForge {version}",
+        html_url=f"https://github.com/SnowfallHD/vodforge/releases/tag/{tag}",
+        notes="",
+        assets=(
+            ReleaseAsset(f"VODForge-Windows-Setup-v{version}.exe", "https://github.com/example/windows", 10),
+            ReleaseAsset(f"VODForge-macOS-arm64-v{version}.zip", "https://github.com/example/mac-arm", 10),
+            ReleaseAsset(f"VODForge-macOS-x64-v{version}.zip", "https://github.com/example/mac-x64", 10),
+        ),
+    )
+
+
+def _app_stub() -> DownloaderApp:
+    app = DownloaderApp.__new__(DownloaderApp)
+    app.update_button = FakeButton()
+    app.status_var = FakeVar("Ready")
+    app.update_check_silent = False
+    app._schedule_auto_update_check = lambda *_args, **_kwargs: None
+    return app
+
+
+def test_silent_current_version_check_does_not_interrupt_user(monkeypatch):
+    app = _app_stub()
+    app.update_check_silent = True
+    monkeypatch.setattr(app_module, "__version__", "1.2.3")
+    shown = []
+    monkeypatch.setattr(app_module.messagebox, "showinfo", lambda *args: shown.append(args))
+
+    app._show_update_result(_release("1.2.3"))
+
+    assert shown == []
+    assert app.status_var.value == "Ready"
+    assert app.update_button.values["text"] == "Check for updates"
+
+
+def test_automatic_check_prompts_for_new_signed_platform_asset(monkeypatch):
+    app = _app_stub()
+    app.update_check_silent = True
+    monkeypatch.setattr(app_module, "__version__", "1.2.3")
+    monkeypatch.setattr(app_module.messagebox, "askyesno", lambda *_args: True)
+    monkeypatch.setattr(app_module, "release_asset_for_platform", lambda release: release.assets[0])
+    started = []
+    app._start_update_download = lambda release: started.append(release.tag_name)
+
+    app._show_update_result(_release("1.2.4"))
+
+    assert started == ["v1.2.4"]
+    assert app.update_button.values["text"] == "Update to v1.2.4"
+
+
+def test_verified_macos_plan_launches_handoff_and_exits_ui(monkeypatch, tmp_path: Path):
+    app = _app_stub()
+    destroyed = []
+    scheduled = []
+    app.destroy = lambda: destroyed.append(True)
+    app.after = lambda delay, callback: scheduled.append((delay, callback))
+    launched = []
+    monkeypatch.setattr(app_module, "launch_macos_update", lambda plan: launched.append(plan))
+    plan = MacUpdatePlan(
+        source_app=tmp_path / "staged-test" / "VODForge.app",
+        target_app=tmp_path / "Applications" / "VODForge.app",
+        staging_root=tmp_path / "staged-test",
+    )
+
+    app._install_downloaded_update(plan)
+
+    assert launched == [plan]
+    assert app.update_button.values == {"state": "disabled", "text": "Installing update…"}
+    assert scheduled[0][0] == 250
+    scheduled[0][1]()
+    assert destroyed == [True]

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
+import plistlib
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -9,12 +12,19 @@ import pytest
 from yt_downloader.updates import (
     ReleaseAsset,
     ReleaseInfo,
+    MacUpdatePlan,
     download_verified_update,
     is_newer_release,
+    launch_macos_update,
     parse_release_payload,
     parse_sha256sums,
+    prepare_macos_update,
     release_asset_for_platform,
+    running_macos_app,
     semantic_version_key,
+    verify_macos_app,
+    verify_windows_authenticode,
+    write_macos_swap_script,
 )
 from yt_downloader.version import DEFAULT_VERSION, read_app_version
 
@@ -157,3 +167,136 @@ def test_verified_update_deletes_tampered_partial_file(monkeypatch: pytest.Monke
 
     assert not (tmp_path / asset_name).exists()
     assert not (tmp_path / f"{asset_name}.part").exists()
+
+
+def _write_mac_app(app_path: Path, *, bundle_id: str = "com.snowfallhd.vodforge") -> None:
+    contents = app_path / "Contents"
+    contents.mkdir(parents=True, exist_ok=True)
+    with (contents / "Info.plist").open("wb") as handle:
+        plistlib.dump({"CFBundleIdentifier": bundle_id}, handle)
+
+
+def _mac_verification_runner(*, team_id: str = "76G5W4954G"):
+    def run(command, **_kwargs):
+        stderr = ""
+        if command[:3] == ["/usr/bin/codesign", "-d", "--verbose=4"]:
+            stderr = f"Identifier=com.snowfallhd.vodforge\nTeamIdentifier={team_id}\n"
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr=stderr)
+
+    return run
+
+
+def test_running_macos_app_finds_only_enclosing_bundle():
+    executable = Path("/Applications/VODForge.app/Contents/MacOS/VODForge")
+    assert running_macos_app(executable) == Path("/Applications/VODForge.app")
+    assert running_macos_app(Path("/usr/local/bin/vodforge")) is None
+
+
+def test_macos_update_requires_exact_bundle_and_team_identity(tmp_path: Path):
+    app_path = tmp_path / "VODForge.app"
+    _write_mac_app(app_path)
+    verify_macos_app(app_path, runner=_mac_verification_runner())
+
+    with pytest.raises(RuntimeError, match="Kryden Ventures"):
+        verify_macos_app(app_path, runner=_mac_verification_runner(team_id="WRONGTEAM"))
+
+    _write_mac_app(app_path, bundle_id="com.example.impostor")
+    with pytest.raises(RuntimeError, match="wrong application identifier"):
+        verify_macos_app(app_path, runner=_mac_verification_runner())
+
+
+def test_prepare_macos_update_extracts_direct_bundle_and_verifies_it(tmp_path: Path):
+    archive = tmp_path / "VODForge-macOS-arm64-v1.2.3.zip"
+    archive.write_bytes(b"release archive")
+    target = tmp_path / "Applications" / "VODForge.app"
+    _write_mac_app(target)
+
+    def runner(command, **kwargs):
+        if command[:4] == ["/usr/bin/ditto", "-x", "-k", str(archive)]:
+            _write_mac_app(Path(command[-1]) / "VODForge.app")
+        return _mac_verification_runner()(command, **kwargs)
+
+    plan = prepare_macos_update(archive, target, runner=runner)
+    assert plan.source_app == plan.staging_root / "VODForge.app"
+    assert plan.target_app == target
+    assert plan.staging_root.name.startswith("staged-")
+
+
+def test_macos_swap_script_reverifies_and_rolls_back(tmp_path: Path):
+    staging = tmp_path / "updates" / "v1.2.3" / "staged-test"
+    source = staging / "VODForge.app"
+    target = tmp_path / "Applications" / "VODForge.app"
+    _write_mac_app(source)
+    _write_mac_app(target)
+    script = write_macos_swap_script(MacUpdatePlan(source, target, staging)).read_text()
+
+    assert "codesign --verify --deep --strict" in script
+    assert "TeamIdentifier=76G5W4954G" in script
+    assert "stapler validate" in script
+    assert "spctl --assess" in script
+    assert 'mv "$old_app" "$target_app"' in script
+
+
+def test_launch_macos_update_uses_detached_argument_safe_handoff(tmp_path: Path):
+    staging = tmp_path / "updates" / "v1.2.3" / "staged-test"
+    source = staging / "VODForge.app"
+    target = tmp_path / "Applications" / "VODForge.app"
+    _write_mac_app(source)
+    _write_mac_app(target)
+    plan = MacUpdatePlan(source, target, staging)
+    calls = []
+
+    class Process:
+        returncode = None
+
+        def poll(self):
+            return None
+
+    def popen(command, **kwargs):
+        calls.append((command, kwargs))
+        return Process()
+
+    launch_macos_update(plan, parent_pid=123, runner=_mac_verification_runner(), popen=popen)
+    command, kwargs = calls[0]
+    assert command[0] == "/bin/bash"
+    assert command[2:] == ["123", str(source), str(target), str(staging)]
+    assert kwargs["start_new_session"] is True
+    assert kwargs["close_fds"] is True
+
+
+def test_windows_update_requires_valid_owned_timestamped_signature(tmp_path: Path):
+    installer = tmp_path / "VODForge-Windows-Setup-v1.2.3.exe"
+    installer.write_bytes(b"signed installer")
+
+    def valid_runner(command, **_kwargs):
+        payload = (
+            '{"Status":"Valid","Subject":"CN=\\"Kryden Ventures, LLC\\", '
+            'O=\\"Kryden Ventures, LLC\\", C=US","Timestamp":"CN=Microsoft Time Stamp"}'
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=payload, stderr="")
+
+    verify_windows_authenticode(installer, runner=valid_runner)
+
+    def unsigned_runner(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout='{"Status":"NotSigned","Subject":"","Timestamp":""}',
+            stderr="",
+        )
+
+    with pytest.raises(RuntimeError, match="Authenticode"):
+        verify_windows_authenticode(installer, runner=unsigned_runner)
+
+    def wrong_publisher_runner(command, **_kwargs):
+        payload = json.dumps(
+            {
+                "Status": "Valid",
+                "Subject": 'CN="Example Corp", O="Example Corp", C=US',
+                "Timestamp": "CN=Microsoft Time Stamp",
+            }
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=payload, stderr="")
+
+    with pytest.raises(RuntimeError, match="Kryden Ventures"):
+        verify_windows_authenticode(installer, runner=wrong_publisher_runner)

--- a/yt_downloader/app.py
+++ b/yt_downloader/app.py
@@ -33,11 +33,17 @@ from .history import (
     upsert_history,
 )
 from .updates import (
+    MacUpdatePlan,
     ReleaseInfo,
+    cleanup_stale_macos_updates,
     download_verified_update,
     fetch_latest_release,
     is_newer_release,
+    launch_macos_update,
+    prepare_macos_update,
     release_asset_for_platform,
+    running_macos_app,
+    verify_windows_authenticode,
 )
 from .version import __version__
 
@@ -86,6 +92,9 @@ VIDEO_CAPS_KBPS = {(480, 30): 2500, (720, 30): 5000, (1080, 30): 10000, (1080, 6
 EXPORT_MODES = ["Auto CBR", "Strict Compliance", "Manual Override"]
 BACKEND_TEMP_OUTPUT_NAME = "__vodforge-tmp.mp4"
 BACKEND_ORIGINAL_BACKUP_NAME = "__vodforge-original.mp4"
+AUTO_UPDATE_INITIAL_DELAY_MS = 5_000
+AUTO_UPDATE_INTERVAL_MS = 6 * 60 * 60 * 1_000
+AUTO_UPDATE_BUSY_RETRY_MS = 10 * 60 * 1_000
 
 
 def diagnostics_dir(
@@ -2012,6 +2021,8 @@ class DownloaderApp(tk.Tk):
         self.events: queue.Queue[tuple[str, Any]] = queue.Queue()
         self.worker: threading.Thread | None = None
         self.update_worker: threading.Thread | None = None
+        self.update_check_silent = False
+        self.update_check_after_id: str | None = None
         self.cancel_requested = False
         self.skip_video_requested = False
         self.skip_url_requested = False
@@ -2054,6 +2065,8 @@ class DownloaderApp(tk.Tk):
         self._load_download_history()
         self._check_runtime()
         self.after(100, self._pump_events)
+        if bool(getattr(sys, "frozen", False)):
+            self._schedule_auto_update_check(AUTO_UPDATE_INITIAL_DELAY_MS)
 
     def _apply_theme(self) -> None:
         style = ttk.Style(self)
@@ -2342,11 +2355,30 @@ class DownloaderApp(tk.Tk):
             self._append_log(f"FFmpeg found: {ffmpeg}")
         self._append_log(f"Diagnostics log: {DIAGNOSTICS_LOG_PATH}")
 
-    def _check_for_updates(self) -> None:
+    def _schedule_auto_update_check(self, delay_ms: int = AUTO_UPDATE_INTERVAL_MS) -> None:
+        if not bool(getattr(sys, "frozen", False)):
+            return
+        if self.update_check_after_id is not None:
+            try:
+                self.after_cancel(self.update_check_after_id)
+            except tk.TclError:
+                pass
+        self.update_check_after_id = self.after(delay_ms, self._run_auto_update_check)
+
+    def _run_auto_update_check(self) -> None:
+        self.update_check_after_id = None
+        if (self.worker and self.worker.is_alive()) or (self.update_worker and self.update_worker.is_alive()):
+            self._schedule_auto_update_check(AUTO_UPDATE_BUSY_RETRY_MS)
+            return
+        self._check_for_updates(silent=True)
+
+    def _check_for_updates(self, *, silent: bool = False) -> None:
         if self.update_worker and self.update_worker.is_alive():
             return
+        self.update_check_silent = silent
         self.update_button.config(state="disabled")
-        self.status_var.set("Checking GitHub Releases for a VODForge update…")
+        if not silent:
+            self.status_var.set("Checking GitHub Releases for a VODForge update…")
         self.update_worker = threading.Thread(target=self._update_check_worker, daemon=True)
         self.update_worker.start()
 
@@ -2357,24 +2389,31 @@ class DownloaderApp(tk.Tk):
             self.events.put(("update_check_error", str(exc)))
 
     def _show_update_result(self, release: ReleaseInfo) -> None:
+        silent = self.update_check_silent
+        self.update_check_silent = False
+        self._schedule_auto_update_check()
         self.update_button.config(state="normal")
         if not is_newer_release(__version__, release.version):
-            self.status_var.set(f"VODForge v{__version__} is up to date.")
-            messagebox.showinfo(APP_NAME, f"You are using the latest VODForge release (v{__version__}).")
+            self.update_button.config(text="Check for updates")
+            if not silent:
+                self.status_var.set(f"VODForge v{__version__} is up to date.")
+                messagebox.showinfo(APP_NAME, f"You are using the latest VODForge release (v{__version__}).")
             return
         self.status_var.set(f"VODForge {release.tag_name} is available.")
-        if sys.platform.startswith("win") and release_asset_for_platform(release) is not None:
+        self.update_button.config(text=f"Update to {release.tag_name}")
+        asset = release_asset_for_platform(release)
+        if asset is None:
             if messagebox.askyesno(
                 APP_NAME,
-                f"VODForge {release.tag_name} is available.\n\nDownload the release artifact, verify its SHA-256 checksum, and start the updater?",
+                f"VODForge {release.tag_name} is available, but there is no automatic update for this computer.\n\nOpen the verified GitHub Release page?",
             ):
-                self._start_update_download(release)
+                webbrowser.open(release.html_url)
             return
         if messagebox.askyesno(
             APP_NAME,
-            f"VODForge {release.tag_name} is available.\n\nOpen the verified GitHub Release page to download it?",
+            f"VODForge {release.tag_name} is available.\n\nDownload the signed update, verify it, and restart VODForge?",
         ):
-            webbrowser.open(release.html_url)
+            self._start_update_download(release)
 
     def _start_update_download(self, release: ReleaseInfo) -> None:
         self.update_button.config(state="disabled")
@@ -2386,12 +2425,33 @@ class DownloaderApp(tk.Tk):
         try:
             destination = application_data_dir() / "updates" / release.tag_name
             path = download_verified_update(release, destination)
-            self.events.put(("update_ready", path))
+            payload: Path | MacUpdatePlan = path
+            if sys.platform == "darwin":
+                target_app = running_macos_app()
+                if target_app is None:
+                    raise RuntimeError("VODForge must be running from the packaged app to update itself.")
+                cleanup_stale_macos_updates(destination)
+                payload = prepare_macos_update(path, target_app)
+            elif sys.platform.startswith("win"):
+                verify_windows_authenticode(path)
+            self.events.put(("update_ready", payload))
         except Exception as exc:
             self.events.put(("update_check_error", str(exc)))
 
-    def _install_downloaded_update(self, path: Path) -> None:
+    def _install_downloaded_update(self, update: Path | MacUpdatePlan) -> None:
         self.update_button.config(state="normal")
+        if isinstance(update, MacUpdatePlan):
+            try:
+                launch_macos_update(update)
+            except Exception as exc:
+                messagebox.showerror(APP_NAME, f"The verified macOS update could not be started:\n\n{exc}")
+                self.status_var.set("The macOS update could not be started.")
+                return
+            self.update_button.config(state="disabled", text="Installing update…")
+            self.status_var.set("Verified update ready. VODForge is restarting to install it…")
+            self.after(250, self.destroy)
+            return
+        path = update
         if not sys.platform.startswith("win") or path.suffix.lower() != ".exe":
             self.status_var.set(f"Verified update downloaded: {path.name}")
             self._open_path(path.parent)
@@ -3370,12 +3430,18 @@ class DownloaderApp(tk.Tk):
                     if isinstance(payload, ReleaseInfo):
                         self._show_update_result(payload)
                 elif kind == "update_ready":
-                    if isinstance(payload, Path):
+                    if isinstance(payload, (Path, MacUpdatePlan)):
                         self._install_downloaded_update(payload)
                 elif kind == "update_check_error":
+                    silent = self.update_check_silent
+                    self.update_check_silent = False
+                    self._schedule_auto_update_check()
                     self.update_button.config(state="normal")
-                    self.status_var.set("Could not check for updates.")
-                    messagebox.showinfo(APP_NAME, str(payload))
+                    if silent:
+                        write_diagnostic(f"automatic update check failed: {payload}")
+                    else:
+                        self.status_var.set("Could not check for updates.")
+                        messagebox.showinfo(APP_NAME, str(payload))
                 elif kind == "done":
                     self.progress_var.set(100)
                     self.status_var.set(str(payload))

--- a/yt_downloader/updates.py
+++ b/yt_downloader/updates.py
@@ -4,14 +4,19 @@ import json
 import hashlib
 import os
 import platform
+import plistlib
 import re
+import shutil
+import subprocess
 import sys
+import textwrap
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Sequence
 
 
 GITHUB_REPOSITORY = "SnowfallHD/vodforge"
@@ -21,6 +26,10 @@ MAX_RELEASE_RESPONSE_BYTES = 2 * 1024 * 1024
 MAX_UPDATE_ASSET_BYTES = 4 * 1024 * 1024 * 1024
 SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$")
 SHA256_RE = re.compile(r"^([0-9a-fA-F]{64})\s+[ *](.+)$")
+MACOS_BUNDLE_ID = "com.snowfallhd.vodforge"
+MACOS_TEAM_ID = "76G5W4954G"
+WINDOWS_PUBLISHER = "Kryden Ventures, LLC"
+MACOS_STAGING_PREFIX = "staged-"
 
 
 @dataclass(frozen=True)
@@ -38,6 +47,13 @@ class ReleaseInfo:
     html_url: str
     notes: str
     assets: tuple[ReleaseAsset, ...]
+
+
+@dataclass(frozen=True)
+class MacUpdatePlan:
+    source_app: Path
+    target_app: Path
+    staging_root: Path
 
 
 def semantic_version_key(version: str) -> tuple[int, int, int, int, str]:
@@ -223,3 +239,226 @@ def download_verified_update(
             temporary.unlink(missing_ok=True)
         except OSError:
             pass
+
+
+def running_macos_app(executable: Path | None = None) -> Path | None:
+    """Return the enclosing installed .app bundle for a frozen macOS executable."""
+    candidate = Path(sys.executable if executable is None else executable)
+    for parent in (candidate, *candidate.parents):
+        if parent.suffix.lower() == ".app":
+            return parent
+    return None
+
+
+def _run_checked(
+    command: Sequence[str],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> subprocess.CompletedProcess[str]:
+    result = runner(list(command), capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "verification failed").strip()
+        raise RuntimeError(detail)
+    return result
+
+
+def verify_macos_app(
+    app_path: Path,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    """Require the exact signed, notarized VODForge application identity."""
+    app_path = Path(app_path)
+    if not app_path.is_dir() or app_path.is_symlink():
+        raise RuntimeError("The macOS update did not contain a regular VODForge.app bundle.")
+    plist_path = app_path / "Contents" / "Info.plist"
+    try:
+        with plist_path.open("rb") as handle:
+            bundle_id = str(plistlib.load(handle).get("CFBundleIdentifier") or "")
+    except (OSError, plistlib.InvalidFileException, TypeError, ValueError) as exc:
+        raise RuntimeError("The macOS update has an unreadable application identity.") from exc
+    if bundle_id != MACOS_BUNDLE_ID:
+        raise RuntimeError("The macOS update has the wrong application identifier.")
+
+    _run_checked(["/usr/bin/codesign", "--verify", "--deep", "--strict", str(app_path)], runner=runner)
+    details = _run_checked(["/usr/bin/codesign", "-d", "--verbose=4", str(app_path)], runner=runner)
+    signing_details = f"{details.stdout}\n{details.stderr}"
+    fields = {}
+    for line in signing_details.splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            fields[key.strip()] = value.strip()
+    if fields.get("Identifier") != MACOS_BUNDLE_ID or fields.get("TeamIdentifier") != MACOS_TEAM_ID:
+        raise RuntimeError("The macOS update is not signed for VODForge by Kryden Ventures.")
+    _run_checked(["/usr/bin/xcrun", "stapler", "validate", str(app_path)], runner=runner)
+    _run_checked(["/usr/sbin/spctl", "--assess", "--type", "execute", "--verbose=2", str(app_path)], runner=runner)
+
+
+def prepare_macos_update(
+    archive_path: Path,
+    target_app: Path,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> MacUpdatePlan:
+    """Extract and verify a downloaded macOS update before the running app exits."""
+    archive_path = Path(archive_path)
+    target_app = Path(target_app)
+    if archive_path.suffix.lower() != ".zip":
+        raise RuntimeError("The macOS update is not a ZIP archive.")
+    if target_app.suffix.lower() != ".app" or not target_app.is_dir() or target_app.is_symlink():
+        raise RuntimeError("VODForge must be running from an installed application bundle to update itself.")
+    if not os.access(target_app.parent, os.W_OK):
+        raise RuntimeError("VODForge cannot replace the installed app at its current location.")
+
+    staging_root = archive_path.parent / f"{MACOS_STAGING_PREFIX}{uuid.uuid4().hex}"
+    staging_root.mkdir(mode=0o700, parents=False, exist_ok=False)
+    try:
+        _run_checked(["/usr/bin/ditto", "-x", "-k", str(archive_path), str(staging_root)], runner=runner)
+        source_app = staging_root / "VODForge.app"
+        verify_macos_app(source_app, runner=runner)
+    except Exception:
+        shutil.rmtree(staging_root, ignore_errors=True)
+        raise
+    return MacUpdatePlan(source_app=source_app, target_app=target_app, staging_root=staging_root)
+
+
+def cleanup_stale_macos_updates(update_root: Path, *, keep: Path | None = None) -> None:
+    """Remove only VODForge-created staging directories from previous update attempts."""
+    update_root = Path(update_root)
+    if not update_root.is_dir():
+        return
+    keep = keep.resolve() if keep is not None else None
+    for child in update_root.iterdir():
+        if not child.name.startswith(MACOS_STAGING_PREFIX) or not child.is_dir() or child.is_symlink():
+            continue
+        if keep is not None and child.resolve() == keep:
+            continue
+        shutil.rmtree(child, ignore_errors=True)
+
+
+def write_macos_swap_script(plan: MacUpdatePlan) -> Path:
+    """Write the detached, rollback-capable macOS app replacement script."""
+    script_path = plan.staging_root / "install-update.sh"
+    script = textwrap.dedent(
+        f"""\
+        #!/bin/bash
+        set -u
+        parent_pid="$1"
+        source_app="$2"
+        target_app="$3"
+        staging_root="$4"
+        new_app="${{target_app}}.vodforge-update-new"
+        old_app="${{target_app}}.vodforge-update-old"
+
+        fail() {{
+          message="$1"
+          /usr/bin/logger -t VODForge "update failed: $message"
+          if [[ ! -e "$target_app" && -e "$old_app" ]]; then /bin/mv "$old_app" "$target_app"; fi
+          if [[ -d "$target_app" ]]; then /usr/bin/open "$target_app"; fi
+          exit 1
+        }}
+
+        [[ "$source_app" == "$staging_root/VODForge.app" ]] || fail "unexpected source path"
+        [[ "$target_app" == *.app ]] || fail "unexpected target path"
+        [[ "$staging_root" == *"/{MACOS_STAGING_PREFIX}"* ]] || fail "unexpected staging path"
+        for _ in $(/usr/bin/seq 1 240); do
+          /bin/kill -0 "$parent_pid" 2>/dev/null || break
+          /bin/sleep 0.5
+        done
+        /bin/kill -0 "$parent_pid" 2>/dev/null && fail "running app did not exit"
+
+        [[ "$new_app" == "$target_app.vodforge-update-new" ]] || fail "unsafe new path"
+        [[ "$old_app" == "$target_app.vodforge-update-old" ]] || fail "unsafe backup path"
+        /bin/rm -rf -- "$new_app" "$old_app"
+        /usr/bin/ditto "$source_app" "$new_app" || fail "could not stage replacement"
+        /usr/bin/codesign --verify --deep --strict "$new_app" || fail "signature verification failed"
+        identity=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$new_app/Contents/Info.plist" 2>/dev/null) || fail "bundle identity missing"
+        [[ "$identity" == "{MACOS_BUNDLE_ID}" ]] || fail "bundle identity mismatch"
+        signing=$(/usr/bin/codesign -d --verbose=4 "$new_app" 2>&1) || fail "signing identity missing"
+        /usr/bin/grep -Fqx 'Identifier={MACOS_BUNDLE_ID}' <<<"$signing" || fail "signed identifier mismatch"
+        /usr/bin/grep -Fqx 'TeamIdentifier={MACOS_TEAM_ID}' <<<"$signing" || fail "team identifier mismatch"
+        /usr/bin/xcrun stapler validate "$new_app" >/dev/null 2>&1 || fail "notarization ticket missing"
+        /usr/sbin/spctl --assess --type execute "$new_app" >/dev/null 2>&1 || fail "Gatekeeper rejected update"
+
+        /bin/mv "$target_app" "$old_app" || fail "could not preserve current app"
+        if /bin/mv "$new_app" "$target_app"; then
+          if /usr/bin/open "$target_app"; then
+            /bin/rm -rf -- "$old_app"
+            /usr/bin/logger -t VODForge "update installed successfully"
+            /bin/rm -rf -- "$staging_root"
+            exit 0
+          fi
+          /bin/rm -rf -- "$target_app"
+          /bin/mv "$old_app" "$target_app" 2>/dev/null || true
+          fail "could not relaunch updated app"
+        fi
+        /bin/mv "$old_app" "$target_app" 2>/dev/null || true
+        fail "could not activate replacement"
+        """
+    )
+    script_path.write_text(script, encoding="utf-8")
+    script_path.chmod(0o700)
+    return script_path
+
+
+def launch_macos_update(
+    plan: MacUpdatePlan,
+    *,
+    parent_pid: int | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    popen: Callable[..., subprocess.Popen[Any]] = subprocess.Popen,
+) -> None:
+    """Launch the verified macOS swapper; the caller must then exit."""
+    verify_macos_app(plan.source_app, runner=runner)
+    script_path = write_macos_swap_script(plan)
+    process = popen(
+        [
+            "/bin/bash",
+            str(script_path),
+            str(os.getpid() if parent_pid is None else parent_pid),
+            str(plan.source_app),
+            str(plan.target_app),
+            str(plan.staging_root),
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        start_new_session=True,
+    )
+    if process.poll() is not None and process.returncode:
+        raise RuntimeError("The macOS update installer could not be started.")
+
+
+def verify_windows_authenticode(
+    installer_path: Path,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    """Require VODForge's exact valid, timestamped Windows publisher signature."""
+    installer_path = Path(installer_path)
+    if installer_path.suffix.lower() != ".exe" or not installer_path.is_file():
+        raise RuntimeError("The Windows update is not an installer executable.")
+    literal_path = str(installer_path).replace("'", "''")
+    command = (
+        f"$signature=Get-AuthenticodeSignature -LiteralPath '{literal_path}';"
+        "$result=[pscustomobject]@{Status=[string]$signature.Status;"
+        "Subject=[string]$signature.SignerCertificate.Subject;"
+        "Timestamp=[string]$signature.TimeStamperCertificate.Subject};"
+        "$result | ConvertTo-Json -Compress"
+    )
+    result = _run_checked(
+        ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", command],
+        runner=runner,
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Windows could not read the update's publisher signature.") from exc
+    subject = str(payload.get("Subject") or "")
+    if str(payload.get("Status") or "") != "Valid":
+        raise RuntimeError("Windows rejected the update's Authenticode signature.")
+    if f'CN="{WINDOWS_PUBLISHER}"' not in subject or f'O="{WINDOWS_PUBLISHER}"' not in subject:
+        raise RuntimeError("The Windows update was not published by Kryden Ventures, LLC.")
+    if not str(payload.get("Timestamp") or "").strip():
+        raise RuntimeError("The Windows update is missing its trusted timestamp.")


### PR DESCRIPTION
## Summary
- check stable GitHub Releases automatically after startup and every six hours
- verify Windows Authenticode publisher/timestamp before silent installation
- verify macOS bundle, Developer ID team, notarization, and Gatekeeper before rollback-capable replacement
- preserve the manual update control and document the release/update behavior

## Verification
- 112 tests passed
- source compilation passed
- generated macOS swapper syntax passed
- local packaged arm64 runtime smoke passed
- published v0.1.0 macOS artifact passed the new identity/signature/notarization verifier
- published v0.1.0 Windows installer independently reported Authenticode Valid with the required publisher and timestamp on desktop-genesis

This PR does not publish a new GitHub Release.