### PR TITLE
Clarify downloads for newer Macs, older Macs, and Windows

### DIFF
--- a/.github/scripts/render_release_notes.py
+++ b/.github/scripts/render_release_notes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Render clear, architecture-specific VODForge GitHub Release notes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+
+REPOSITORY = "SnowfallHD/vodforge"
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def asset_url(version: str, filename: str) -> str:
+    return f"https://github.com/{REPOSITORY}/releases/download/v{version}/{filename}"
+
+
+def render_release_notes(version: str, *, draft: bool = False) -> str:
+    if not VERSION_RE.fullmatch(version):
+        raise ValueError("Version must use semantic versioning, for example 1.2.3.")
+
+    mac_arm = f"VODForge-macOS-arm64-v{version}.zip"
+    mac_intel = f"VODForge-macOS-x64-v{version}.zip"
+    windows_installer = f"VODForge-Windows-Setup-v{version}.exe"
+    windows_portable = f"VODForge-Windows-Portable-v{version}.zip"
+    draft_notice = ""
+    if draft:
+        draft_notice = (
+            "> **Release-team draft:** Do not publish until both Mac downloads have been "
+            "Developer ID signed, notarized, stapled, independently verified, and the "
+            "checksums regenerated.\n\n"
+        )
+
+    return f"""{draft_notice}## Download VODForge
+
+### Newer Macs — Apple silicon
+
+**Usually Macs from late 2020 and newer. Recommended for most Mac users.**
+
+[Download VODForge for Apple silicon]({asset_url(version, mac_arm)})
+
+Choose this when **About This Mac** shows a **Chip** such as Apple M1, M2, M3, M4, or newer.
+
+### Older Macs — Intel-based
+
+**Generally Macs from 2020 and earlier.**
+
+[Download VODForge for an Intel-based Mac]({asset_url(version, mac_intel)})
+
+Choose this only when **About This Mac** shows an **Intel Processor**. Using this download on an Apple silicon Mac can cause macOS to display an Intel-app compatibility warning.
+
+### Windows
+
+**Recommended:** [Download the Windows installer]({asset_url(version, windows_installer)})
+
+[Download the portable Windows version]({asset_url(version, windows_portable)}) only if you specifically do not want an installed app.
+
+## About this release
+
+- VODForge checks stable GitHub Releases automatically after startup and every six hours.
+- Updates are downloaded only after approval and are verified before installation.
+- Windows downloads are signed by Kryden Ventures, LLC.
+- Mac downloads are Developer ID signed, notarized, and provided separately for Apple silicon and Intel-based Macs.
+
+Checksums for every download are available in `SHA256SUMS.txt` below.
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("--draft", action="store_true")
+    args = parser.parse_args()
+    print(render_release_notes(args.version, draft=args.draft), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
     needs: [windows, macos]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           path: release
@@ -133,9 +134,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          python3 .github/scripts/render_release_notes.py "${{ inputs.version }}" --draft > release-notes.md
           gh release create "v${{ inputs.version }}" release/* \
             --repo "${{ github.repository }}" \
             --target "${{ github.sha }}" \
             --title "VODForge v${{ inputs.version }}" \
-            --notes "Signed Windows installer and portable archive, plus unsigned macOS review builds. Do not publish the draft until both macOS architectures are Developer ID signed, notarized, stapled, and the checksums are regenerated." \
+            --notes-file release-notes.md \
             --draft

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ VODForge analyzes the available source streams, chooses a practical video/audio 
 
 ## Install a packaged release
 
-GitHub Releases are the intended public download channel. On Windows, use the per-user `VODForge-Windows-Setup` installer. It installs under `%LOCALAPPDATA%\Programs\VODForge`, keeps the packaged `_internal` runtime beside the app automatically, adds normal shortcuts, and provides an uninstaller. The portable ZIP remains available for users who specifically want it.
+GitHub Releases are the intended public download channel. Release notes put the recommended **Newer Macs — Apple silicon** download first (usually late 2020 and newer), followed by **Older Macs — Intel-based** (generally 2020 and earlier) and **Windows**. Because model years overlap, Mac users should rely on **About This Mac**: choose Apple silicon when it shows **Chip**, and Intel when it shows **Processor**.
+
+On Windows, use the per-user `VODForge-Windows-Setup` installer. It installs under `%LOCALAPPDATA%\Programs\VODForge`, keeps the packaged `_internal` runtime beside the app automatically, adds normal shortcuts, and provides an uninstaller. The portable ZIP remains available for users who specifically want it.
 
 The macOS release is a normal `VODForge.app`; its bundled runtime is inside the application package. Public macOS releases are Developer ID signed, notarized, stapled, and Gatekeeper-checked before publication. Unsigned workflow artifacts are explicitly named `unsigned-review` and are never public-ready downloads.
 

--- a/finalize_macos_release.sh
+++ b/finalize_macos_release.sh
@@ -86,6 +86,8 @@ gh release upload "$tag" --repo "$repo" --clobber \
   "$finalize_dir/SHA256SUMS.txt"
 gh release delete-asset "$tag" "$arm_unsigned" --repo "$repo" --yes
 gh release delete-asset "$tag" "$x64_unsigned" --repo "$repo" --yes
+python3 .github/scripts/render_release_notes.py "$version" > "$finalize_dir/release-notes.md"
+gh release edit "$tag" --repo "$repo" --notes-file "$finalize_dir/release-notes.md"
 
 echo "Final signed artifacts and checksums uploaded to draft release $tag."
 echo "Review the release assets and checksums before publishing."

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,7 +1,18 @@
 from pathlib import Path
 
+from importlib.util import module_from_spec, spec_from_file_location
+
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _release_notes_module():
+    path = ROOT / ".github" / "scripts" / "render_release_notes.py"
+    spec = spec_from_file_location("render_release_notes", path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_release_workflow_signs_before_packaging_windows_portable_archive():
@@ -23,7 +34,8 @@ def test_release_workflow_keeps_macos_artifacts_explicitly_review_only():
 
     assert "vodforge-macos-${{ matrix.architecture }}-unsigned" in workflow
     assert 'VODFORGE_UNSIGNED_REVIEW: "1"' in workflow
-    assert "Do not publish the draft until both macOS architectures" in workflow
+    assert "render_release_notes.py" in workflow
+    assert "--draft" in workflow
 
 
 def test_macos_dependency_install_recovers_only_when_every_formula_is_present():
@@ -51,3 +63,27 @@ def test_release_finalizer_replaces_unsigned_reviews_and_regenerates_checksums()
     assert "sign_and_notarize_macos.sh" in script
     assert "SHA256SUMS.txt" in script
     assert "release delete-asset" in script
+    assert 'release edit "$tag"' in script
+
+
+def test_release_notes_lead_with_clear_user_facing_platform_choices():
+    notes = _release_notes_module().render_release_notes("1.2.3")
+
+    newer = notes.index("### Newer Macs — Apple silicon")
+    older = notes.index("### Older Macs — Intel-based")
+    windows = notes.index("### Windows")
+    assert newer < older < windows
+    assert "late 2020 and newer" in notes
+    assert "2020 and earlier" in notes
+    assert "About This Mac" in notes
+    assert "VODForge-macOS-arm64-v1.2.3.zip" in notes
+    assert "VODForge-macOS-x64-v1.2.3.zip" in notes
+    assert "VODForge-Windows-Setup-v1.2.3.exe" in notes
+
+
+def test_draft_release_notes_keep_the_release_team_safety_gate():
+    notes = _release_notes_module().render_release_notes("1.2.3", draft=True)
+
+    assert "Release-team draft" in notes
+    assert "Do not publish" in notes
+    assert "notarized" in notes


### PR DESCRIPTION
## Summary
- lead release notes with direct, user-friendly platform downloads
- put newer Apple-silicon Macs first and older Intel Macs second, with approximate model years and the reliable About This Mac distinction
- keep Windows installer recommended and portable download secondary
- automatically replace the internal draft warning with public release notes after Mac signing finalization

## Verification
- 114 tests passed
- workflow YAML parsed successfully
- release and signing shell scripts passed syntax validation
- rendered v0.1.1 release-note links match the updater asset contract

After this PR is green and merged, v0.1.1 will be built, signed, notarized, independently verified, and published.