### PR TITLE
Allow bounded Intel runtime cold start under Rosetta

### DIFF
--- a/tests/test_metadata_helpers.py
+++ b/tests/test_metadata_helpers.py
@@ -9,6 +9,7 @@ import pytest
 
 import yt_downloader.app as app_module
 from yt_downloader.app import (
+    RUNTIME_SMOKE_PROBE_TIMEOUT_SECONDS,
     AUDIO_BITRATE,
     AUDIO_SAMPLE_RATE,
     DownloadJob,
@@ -114,6 +115,10 @@ def test_runtime_version_commands_use_each_tool_cli_contract():
     assert runtime_version_command("ffmpeg", "/bundle/ffmpeg") == ["/bundle/ffmpeg", "-version"]
     assert runtime_version_command("ffprobe", "/bundle/ffprobe") == ["/bundle/ffprobe", "-version"]
     assert runtime_version_command("deno", "/bundle/deno") == ["/bundle/deno", "--version"]
+
+
+def test_runtime_smoke_timeout_allows_bounded_rosetta_cold_translation():
+    assert RUNTIME_SMOKE_PROBE_TIMEOUT_SECONDS == 60
 
 
 def test_build_tags_display_text_uses_comma_space_for_copying():

--- a/yt_downloader/app.py
+++ b/yt_downloader/app.py
@@ -95,6 +95,7 @@ BACKEND_ORIGINAL_BACKUP_NAME = "__vodforge-original.mp4"
 AUTO_UPDATE_INITIAL_DELAY_MS = 5_000
 AUTO_UPDATE_INTERVAL_MS = 6 * 60 * 60 * 1_000
 AUTO_UPDATE_BUSY_RETRY_MS = 10 * 60 * 1_000
+RUNTIME_SMOKE_PROBE_TIMEOUT_SECONDS = 60
 
 
 def diagnostics_dir(
@@ -213,7 +214,9 @@ def probe_runtime_version(tool_name: str, executable: str) -> str:
         text=True,
         encoding="utf-8",
         errors="replace",
-        timeout=15,
+        # Rosetta's first translation of the Intel Deno binary can take around
+        # 30 seconds on Apple silicon; keep the release gate bounded above it.
+        timeout=RUNTIME_SMOKE_PROBE_TIMEOUT_SECONDS,
         startupinfo=startupinfo,
         creationflags=creationflags,
     )


### PR DESCRIPTION
## Cause
The v0.1.1 finalizer stopped fail-closed after Apple accepted both Mac builds because Intel Deno's first Rosetta translation exceeded the 15-second runtime-smoke timeout.

Exact-artifact measurement showed a healthy but cold first run at about 28 seconds, followed by approximately 2-second runs. Native Intel CI had already passed the same packaged runtime smoke.

## Fix
Raise only the bundled-runtime smoke probe timeout to a still-bounded 60 seconds. This preserves the release gate while accommodating first-time Rosetta translation.

## Verification
- 115 tests passed
- source compilation passed
- exact x64 Deno artifact: first Rosetta run 28.08s, subsequent runs 2.01s and 1.79s
- v0.1.1 remains an unpublished draft